### PR TITLE
More torch backend

### DIFF
--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -250,6 +250,27 @@ def test_cosh():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: cosh"
 
+def test_logaddexp():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x_1 = py_rand.randn(shape)
+    py_x_2 = py_rand.randn(shape)
+
+    torch_x_1 = torch_matrix.float_tensor(py_x_1)
+    torch_x_2 = torch_matrix.float_tensor(py_x_2)
+
+    py_y = py_func.logaddexp(py_x_1, py_x_2)
+    torch_y = torch_func.logaddexp(torch_x_1, torch_x_2)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: cosh"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: cosh"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -264,4 +285,5 @@ if __name__ == "__main__":
     test_square()
     test_tpow()
     test_cosh()
+    test_logaddexp()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -289,6 +289,24 @@ def test_acosh():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: acosh"
 
+def test_logit():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.rand(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.logit(py_x)
+    torch_y = torch_func.logit(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: logit"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: logit"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -306,4 +324,5 @@ if __name__ == "__main__":
     test_logaddexp()
     test_logcosh()
     test_acosh()
+    test_logit()
 

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -343,6 +343,24 @@ def test_cos():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: cos"
 
+def test_sin():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.sin(py_x)
+    torch_y = torch_func.sin(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: sin"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: sin"
+
 
 if __name__ == "__main__":
     test_conversion()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -177,6 +177,24 @@ def test_atanh():
     assert torch_matrix.allclose(torch_y, torch_py_y, rtol=1e-05, atol=1e-07), \
     "torch -> python -> torch failure: atanh"
 
+def test_sqrt():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.rand(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.sqrt(py_x)
+    torch_y = torch_func.sqrt(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: sqrt"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: sqrt"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -187,4 +205,5 @@ if __name__ == "__main__":
     test_expit()
     test_reciprocal()
     test_atanh()
+    test_sqrt()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -325,6 +325,24 @@ def test_softplus():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: softplus"
 
+def test_cos():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.cos(py_x)
+    torch_y = torch_func.cos(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: cos"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: cos"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -344,3 +362,4 @@ if __name__ == "__main__":
     test_acosh()
     test_logit()
     test_softplus()
+    test_cos()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -307,6 +307,24 @@ def test_logit():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: logit"
 
+def test_softplus():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.softplus(py_x)
+    torch_y = torch_func.softplus(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: softplus"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: softplus"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -325,4 +343,4 @@ if __name__ == "__main__":
     test_logcosh()
     test_acosh()
     test_logit()
-
+    test_softplus()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -232,6 +232,25 @@ def test_tpow():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: tpow"
 
+def test_cosh():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.cosh(py_x)
+    torch_y = torch_func.cosh(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: cosh"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: cosh"
+
+
 if __name__ == "__main__":
     test_conversion()
     test_acosh()
@@ -244,4 +263,5 @@ if __name__ == "__main__":
     test_sqrt()
     test_square()
     test_tpow()
+    test_cosh()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -271,6 +271,24 @@ def test_logaddexp():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: cosh"
 
+def test_logcosh():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.logcosh(py_x)
+    torch_y = torch_func.logcosh(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: logcosh"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: logcosh"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -286,4 +304,5 @@ if __name__ == "__main__":
     test_tpow()
     test_cosh()
     test_logaddexp()
+    test_logcosh()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -213,6 +213,24 @@ def test_square():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: square"
 
+def test_tpow():
+    shape = (100, 100)
+    power = 3
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.tpow(py_x, power)
+    torch_y = torch_func.tpow(torch_x, power)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: tpow"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: tpow"
 
 if __name__ == "__main__":
     test_conversion()
@@ -225,4 +243,5 @@ if __name__ == "__main__":
     test_atanh()
     test_sqrt()
     test_square()
+    test_tpow()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -195,6 +195,24 @@ def test_sqrt():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: sqrt"
 
+def test_square():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = py_rand.randn(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.square(py_x)
+    torch_y = torch_func.square(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: square"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: square"
+
 
 if __name__ == "__main__":
     test_conversion()
@@ -206,4 +224,5 @@ if __name__ == "__main__":
     test_reciprocal()
     test_atanh()
     test_sqrt()
+    test_square()
     test_tabs()

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -31,24 +31,6 @@ def test_conversion():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure"
 
-def test_acosh():
-    shape = (100, 100)
-    py_rand.set_seed()
-    py_x = 1 + py_rand.rand(shape)
-    torch_x = torch_matrix.float_tensor(py_x)
-
-    py_y = py_func.acosh(py_x)
-    torch_y = torch_func.acosh(torch_x)
-
-    torch_py_y = torch_matrix.float_tensor(py_y)
-    py_torch_y = torch_matrix.to_numpy_array(torch_y)
-
-    assert py_matrix.allclose(py_y, py_torch_y), \
-    "python -> torch -> python failure: acosh"
-
-    assert torch_matrix.allclose(torch_y, torch_py_y), \
-    "torch -> python -> torch failure: acosh"
-
 def test_tabs():
     shape = (100, 100)
     py_rand.set_seed()
@@ -289,10 +271,28 @@ def test_logcosh():
     assert torch_matrix.allclose(torch_y, torch_py_y), \
     "torch -> python -> torch failure: logcosh"
 
+def test_acosh():
+    shape = (100, 100)
+    py_rand.set_seed()
+    py_x = 1 + py_rand.rand(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_y = py_func.acosh(py_x)
+    torch_y = torch_func.acosh(torch_x)
+
+    torch_py_y = torch_matrix.float_tensor(py_y)
+    py_torch_y = torch_matrix.to_numpy_array(torch_y)
+
+    assert py_matrix.allclose(py_y, py_torch_y), \
+    "python -> torch -> python failure: acosh"
+
+    assert torch_matrix.allclose(torch_y, torch_py_y), \
+    "torch -> python -> torch failure: acosh"
+
 
 if __name__ == "__main__":
     test_conversion()
-    test_acosh()
+    test_tabs()
     test_exp()
     test_log()
     test_tanh()
@@ -305,4 +305,5 @@ if __name__ == "__main__":
     test_cosh()
     test_logaddexp()
     test_logcosh()
-    test_tabs()
+    test_acosh()
+

--- a/paysage/backends/backend_tests.py
+++ b/paysage/backends/backend_tests.py
@@ -381,3 +381,4 @@ if __name__ == "__main__":
     test_logit()
     test_softplus()
     test_cos()
+    test_sin()

--- a/paysage/backends/python_backend/nonlinearity.py
+++ b/paysage/backends/python_backend/nonlinearity.py
@@ -1,7 +1,7 @@
 import numpy
 import numexpr as ne
 
-EPSILON = numpy.finfo(numpy.float32).eps
+EPSILON = float(numpy.finfo(numpy.float32).eps)
 LOG2 = 0.6931471805599453
 
 def tabs(x):

--- a/paysage/backends/pytorch_backend/nonlinearity.py
+++ b/paysage/backends/pytorch_backend/nonlinearity.py
@@ -1,7 +1,7 @@
 import numpy, torch
 from . import matrix
 
-EPSILON = numpy.finfo(numpy.float32).eps
+EPSILON = float(numpy.finfo(numpy.float32).eps)
 LOG2 = 0.6931471805599453
 
 def tabs(x):

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -1,13 +1,10 @@
-#from .python_backend import matrix as pymat
-#from .pytorch_backend import matrix as torchmat
+import paysage.backends.python_backend.matrix as py_matrix
+import paysage.backends.python_backend.nonlinearity as py_func
+import paysage.backends.python_backend.rand as py_rand
 
-import python_backend.matrix as py_matrix
-import python_backend.nonlinearity as py_func
-import python_backend.rand as py_rand
-
-import pytorch_backend.matrix as torch_matrix
-import pytorch_backend.nonlinearity as torch_func
-import pytorch_backend.rand as torch_rand
+import paysage.backends.pytorch_backend.matrix as torch_matrix
+import paysage.backends.pytorch_backend.nonlinearity as torch_func
+import paysage.backends.pytorch_backend.rand as torch_rand
 
 import pytest
 


### PR DESCRIPTION
Tests for all of the backend nonlinearity functions are implemented. Also, moved the tests from the backend folder to the tests folder. 

One thing to take note of is that I changed EPSILON from a float32 to a float (which in python is float64). The issue is that expressions such as `1+EPSILON` automatically cast to float64, which results in type errors from torch. The alternative is to explicitly cast `np.float32(1+EPSILON)`. Probably doesn't matter much while running on the CPU but could be important when we start providing GPU support (which will be soon).