### PR TITLE
Put Tuple back in typedef

### DIFF
--- a/paysage/backends/pytorch_backend/typedef.py
+++ b/paysage/backends/pytorch_backend/typedef.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union
+from typing import Iterable, Tuple, Union
 from numpy import ndarray
 from torch import IntTensor, ShortTensor, LongTensor
 from torch import ByteTensor


### PR DESCRIPTION
Tuple is needed to describe shapes of tensors.