### PR TITLE
Saving models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On MaxOSX with PyEnv:
 4. Clone this git repo
 5. Move into the directory with setup.py
 6. Run "pip3 install -e ."
-7. Make a new file ~/.matplotlib/matplotlibrc with the text "backend: TkAgg"
+7. Make a new file ~/.matplotlib/matplotlibrc with the text "backend: TkAgg". This fixes an issue with importing matplotlib in a virtual enviroment. Check out this [post](http://stackoverflow.com/questions/21784641/installation-issue-with-matplotlib-python) for more information.
 
 Running the examples requires a file mnist.h5 containing the MNIST dataset of handwritten images. The script download_mnist.py in the mnist/ folder will fetch the file from the web.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Soon, we will be adding support for:
 
 
 ## Installation:
-On Ubuntu 16.4 with Anaconda3:
+With Anaconda3:
 1. Clone this git repo
 2. Move into the directory with setup.py
 3. Run “pip install -e .”

--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@ Soon, we will be adding support for:
 
 
 ## Installation:
+On Ubuntu 16.4 with Anaconda3:
 1. Clone this git repo
 2. Move into the directory with setup.py
 3. Run “pip install -e .”
+
+On MaxOSX with PyEnv:
+1. Install pyenv, install python 3.6.0 and set python3 to the python 3.6.0 installation
+2. Install llvm 3.9 manually with homebrew
+3. Set the LLVM_CONFIG environment variable to the llvm-config file in the llvm 3.9 configuration
+4. Clone this git repo
+5. Move into the directory with setup.py
+6. Run "pip3 install -e ."
+7. Make a new file ~/.matplotlib/matplotlibrc with the text "backend: TkAgg"
 
 Running the examples requires a file mnist.h5 containing the MNIST dataset of handwritten images. The script download_mnist.py in the mnist/ folder will fetch the file from the web.
 

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -64,7 +64,7 @@ class Layer(object):
     @classmethod
     def from_config(cls, config):
         """
-        Construct the layer from the configuration.
+        Construct the layer from the base configuration.
 
         Notes:
             A layer constructor from the configuration.
@@ -215,8 +215,7 @@ class Weights(Layer):
 
     @classmethod
     def from_config(cls, config):
-        shape = config["shape"]
-        layer = cls(shape)
+        layer = cls(config["shape"])
         for k, v in config["penalties"]:
             layer.add_penalty({k: getattr(penalties, v)})
         for k, v in config["constraints"]:
@@ -328,6 +327,16 @@ class GaussianLayer(Layer):
         base_config["num_units"] = self.len
         base_config["sample_size"] = self.sample_size
         return base_config
+
+    @classmethod
+    def from_config(cls, config):
+        layer = cls(config["num_units"])
+        layer.sample_size = config["sample_size"]
+        for k, v in config["penalties"]:
+            layer.add_penalty({k: getattr(penalties, v)})
+        for k, v in config["constraints"]:
+            layer.add_constraint({k: getattr(constraints, v)})
+        return layer
 
     def energy(self, vis):
         """
@@ -613,6 +622,16 @@ class IsingLayer(Layer):
         base_config["sample_size"] = self.sample_size
         return base_config
 
+    @classmethod
+    def from_config(cls, config):
+        layer = cls(config["num_units"])
+        layer.sample_size = config["sample_size"]
+        for k, v in config["penalties"]:
+            layer.add_penalty({k: getattr(penalties, v)})
+        for k, v in config["constraints"]:
+            layer.add_constraint({k: getattr(constraints, v)})
+        return layer
+
     def energy(self, data):
         return -be.dot(data, self.int_params['loc'])
 
@@ -712,6 +731,16 @@ class BernoulliLayer(Layer):
         base_config["sample_size"] = self.sample_size
         return base_config
 
+    @classmethod
+    def from_config(cls, config):
+        layer = cls(config["num_units"])
+        layer.sample_size = config["sample_size"]
+        for k, v in config["penalties"]:
+            layer.add_penalty({k: getattr(penalties, v)})
+        for k, v in config["constraints"]:
+            layer.add_constraint({k: getattr(constraints, v)})
+        return layer
+
     def energy(self, data):
         return -be.dot(data, self.int_params['loc'])
 
@@ -810,6 +839,16 @@ class ExponentialLayer(Layer):
         base_config["num_units"] = self.len
         base_config["sample_size"] = self.sample_size
         return base_config
+
+    @classmethod
+    def from_config(cls, config):
+        layer = cls(config["num_units"])
+        layer.sample_size = config["sample_size"]
+        for k, v in config["penalties"]:
+            layer.add_penalty({k: getattr(penalties, v)})
+        for k, v in config["constraints"]:
+            layer.add_constraint({k: getattr(constraints, v)})
+        return layer
 
     def energy(self, data):
         return be.dot(data, self.int_params['loc'])

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -16,8 +16,32 @@ class Layer(object):
 
         """
         self.int_params = {}
+        self.ext_params = {}
         self.penalties = OrderedDict()
         self.constraints = OrderedDict()
+
+    def base_config(self):
+        """
+        Get a base configuration for the layer.
+
+        Notes:
+            Encodes metadata for the layer.
+            Includes the base layer data.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary configuration for the layer.
+        """
+        return {"layer_type": self.__class__.__name__,
+                "intrinsic": list(self.int_params.keys()),
+                "extrinsic": list(self.ext_params.keys()),
+                "penalties": {pk: self.penalties[pk].__name__
+                                for pk in self.penalties},
+                "constraints": {ck: self.constraints[ck].__name__
+                                for ck in self.constraints}
+               }
 
     def add_constraint(self, constraint):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -20,7 +20,7 @@ class Layer(object):
         self.penalties = OrderedDict()
         self.constraints = OrderedDict()
 
-    def base_config(self):
+    def get_base_config(self):
         """
         Get a base configuration for the layer.
 
@@ -147,6 +147,39 @@ class Layer(object):
         be.subtract_dicts_inplace(self.int_params, deltas)
         self.enforce_constraints()
 
+    def get_config(self):
+        """
+        Get a full configuration for the layer.
+
+        Notes:
+            Encodes metadata on the layer.
+            Weights are separately retrieved.
+            Builds the base configuration.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary configuration for the layer.
+        """
+        return get_base_config()
+
+    @classmethod
+    def from_config(cls):
+        """
+        Construct the layer from the configuration.
+
+        Notes:
+            A layer constructor from the configuration.
+
+        Args:
+            None
+
+        Returns:
+            An object which is a subclass of `Layer`.
+        """
+        raise NotImplementedError
+
 
 class Weights(Layer):
     """Layer class for weights"""
@@ -173,6 +206,11 @@ class Weights(Layer):
         self.int_params = {
         'matrix': 0.01 * be.randn(shape)
         }
+
+    def get_config(self):
+        base_config = self.get_base_config()
+        base_config["shape"] = self.shape
+        return base_config
 
     def W(self):
         """
@@ -273,6 +311,12 @@ class GaussianLayer(Layer):
         'mean': None,
         'variance': None
         }
+
+    def get_config(self):
+        base_config = self.get_base_config()
+        base_config["num_units"] = self.len
+        base_config["sample_size"] = self.sample_size
+        return base_config
 
     def energy(self, vis):
         """
@@ -552,6 +596,12 @@ class IsingLayer(Layer):
         'field': None
         }
 
+    def get_config(self):
+        base_config = self.get_base_config()
+        base_config["num_units"] = self.len
+        base_config["sample_size"] = self.sample_size
+        return base_config
+
     def energy(self, data):
         return -be.dot(data, self.int_params['loc'])
 
@@ -645,6 +695,12 @@ class BernoulliLayer(Layer):
         'field': None
         }
 
+    def get_config(self):
+        base_config = self.get_base_config()
+        base_config["num_units"] = self.len
+        base_config["sample_size"] = self.sample_size
+        return base_config
+
     def energy(self, data):
         return -be.dot(data, self.int_params['loc'])
 
@@ -737,6 +793,12 @@ class ExponentialLayer(Layer):
         self.ext_params = {
         'rate': None
         }
+
+    def get_config(self):
+        base_config = self.get_base_config()
+        base_config["num_units"] = self.len
+        base_config["sample_size"] = self.sample_size
+        return base_config
 
     def energy(self, data):
         return be.dot(data, self.int_params['loc'])

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -33,7 +33,7 @@ class Layer(object):
             None
 
         """
-        self.constraint.update(constraint)
+        self.constraints.update(constraint)
 
     def enforce_constraints(self):
         """
@@ -50,7 +50,7 @@ class Layer(object):
 
         """
         for param_name in self.constraints:
-            self.constraint[param_name](self.int_params[param_name])
+            self.constraints[param_name](self.int_params[param_name])
 
     def add_penalty(self, penalty):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 
 from . import backends as be
@@ -62,8 +63,8 @@ class Layer(object):
         """
         return get_base_config()
 
-    @classmethod
-    def from_config(cls, config):
+    @staticmethod
+    def from_config(config):
         """
         Construct the layer from the base configuration.
 
@@ -73,7 +74,8 @@ class Layer(object):
         Returns:
             An object which is a subclass of `Layer`.
         """
-        raise NotImplementedError
+        layer_obj = getattr(sys.modules[__name__], config["layer_type"])
+        return layer_obj.from_config(config)
 
     def add_constraint(self, constraint):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -67,11 +67,8 @@ class Layer(object):
         """
         Construct the layer from the base configuration.
 
-        Notes:
-            A layer constructor from the configuration.
-
         Args:
-            None
+            A dictionary configuration of the layer metadata.
 
         Returns:
             An object which is a subclass of `Layer`.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -35,14 +35,15 @@ class Layer(object):
         Returns:
             A dictionary configuration for the layer.
         """
-        return {"layer_type": self.__class__.__name__,
-                "intrinsic": list(self.int_params.keys()),
-                "extrinsic": list(self.ext_params.keys()),
-                "penalties": {pk: self.penalties[pk].__name__
-                                for pk in self.penalties},
-                "constraints": {ck: self.constraints[ck].__name__
-                                for ck in self.constraints}
-               }
+        return {
+        "layer_type": self.__class__.__name__,
+        "intrinsic": list(self.int_params.keys()),
+        "extrinsic": list(self.ext_params.keys()),
+        "penalties": {pk: self.penalties[pk].__name__
+                        for pk in self.penalties},
+        "constraints": {ck: self.constraints[ck].__name__
+                        for ck in self.constraints}
+        }
 
     def get_config(self):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -43,7 +43,7 @@ class Layer(object):
         "layer_type": self.__class__.__name__,
         "intrinsic": list(self.int_params.keys()),
         "extrinsic": list(self.ext_params.keys()),
-        "penalties": {pk: self.penalties[pk].__name__
+        "penalties": {pk: self.penalties[pk].__class__.__name__
                         for pk in self.penalties},
         "constraints": {ck: self.constraints[ck].__name__
                         for ck in self.constraints}

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -16,8 +16,8 @@ class Layer(object):
 
         """
         self.int_params = {}
-        self.penalties = {}
-        self.constraints = {}
+        self.penalties = OrderedDict()
+        self.constraints = OrderedDict()
 
     def add_constraint(self, constraint):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -1,5 +1,6 @@
-from . import backends as be
+from collections import OrderedDict
 
+from . import backends as be
 
 class Layer(object):
     """A general layer class with common functionality."""
@@ -61,7 +62,7 @@ class Layer(object):
         return get_base_config()
 
     @classmethod
-    def from_config(cls):
+    def from_config(cls, config):
         """
         Construct the layer from the configuration.
 
@@ -211,6 +212,16 @@ class Weights(Layer):
         base_config = self.get_base_config()
         base_config["shape"] = self.shape
         return base_config
+
+    @classmethod
+    def from_config(cls, config):
+        shape = config["shape"]
+        layer = cls(shape)
+        for k, v in config["penalties"]:
+            layer.add_penalty({k: getattr(penalties, v)})
+        for k, v in config["constraints"]:
+            layer.add_constraint({k: getattr(constraints, v)})
+        return layer
 
     def W(self):
         """

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -43,6 +43,39 @@ class Layer(object):
                                 for ck in self.constraints}
                }
 
+    def get_config(self):
+        """
+        Get a full configuration for the layer.
+
+        Notes:
+            Encodes metadata on the layer.
+            Weights are separately retrieved.
+            Builds the base configuration.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary configuration for the layer.
+        """
+        return get_base_config()
+
+    @classmethod
+    def from_config(cls):
+        """
+        Construct the layer from the configuration.
+
+        Notes:
+            A layer constructor from the configuration.
+
+        Args:
+            None
+
+        Returns:
+            An object which is a subclass of `Layer`.
+        """
+        raise NotImplementedError
+
     def add_constraint(self, constraint):
         """
         Add a parameter constraint to the layer.
@@ -146,39 +179,6 @@ class Layer(object):
         """
         be.subtract_dicts_inplace(self.int_params, deltas)
         self.enforce_constraints()
-
-    def get_config(self):
-        """
-        Get a full configuration for the layer.
-
-        Notes:
-            Encodes metadata on the layer.
-            Weights are separately retrieved.
-            Builds the base configuration.
-
-        Args:
-            None
-
-        Returns:
-            A dictionary configuration for the layer.
-        """
-        return get_base_config()
-
-    @classmethod
-    def from_config(cls):
-        """
-        Construct the layer from the configuration.
-
-        Notes:
-            A layer constructor from the configuration.
-
-        Args:
-            None
-
-        Returns:
-            An object which is a subclass of `Layer`.
-        """
-        raise NotImplementedError
 
 
 class Weights(Layer):

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -77,10 +77,10 @@ class Model(object):
             An instance of the model.
 
         """
-        layers = []
+        layer_list = []
         for ly in config["layers"]:
-            layers.append(Layer.from_config(ly))
-        return cls(layers)
+            layer_list.append(layers.Layer.from_config(ly))
+        return cls(layer_list)
 
     def initialize(self, data, method='hinton'):
         """

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -45,6 +45,43 @@ class Model(object):
         for i in range(len(self.layers) - 1)
         ]
 
+    def get_config(self):
+        """
+        Get a configuration for the model.
+
+        Notes:
+            Includes metadata on the layers.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary configuration for the model.
+
+        """
+        config = {
+        "model type": "RBM",
+        "layers": [ly.get_config() for ly in self.layers],
+        }
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        """
+        Build a model from the configuration.
+
+        Args:
+            A dictionary configuration of the model metadata.
+
+        Returns:
+            An instance of the model.
+
+        """
+        layers = []
+        for ly in config["layers"]:
+            layers.append(Layer.from_config(ly))
+        return cls(layers)
+
     def initialize(self, data, method='hinton'):
         """
         Inialize the parameters of the model.

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -1,0 +1,60 @@
+from paysage import layers
+from paysage import constraints
+from paysage import penalties
+from paysage import backends as be
+
+
+# ----- CONSTRUCTORS ----- #
+
+def test_Layer_creation():
+    layers.Layer()
+
+def test_Weights_creation():
+    layers.Weights((8,5))
+
+def test_Gaussian_creation():
+    layers.GaussianLayer(8)
+
+def test_Ising_creation():
+    layers.IsingLayer(8)
+
+def test_Bernoulli_creation():
+    layers.BernoulliLayer(8)
+
+def test_Exponential_creation():
+    layers.ExponentialLayer(8)
+
+
+# ----- BASE METHODS ----- #
+
+def test_add_constraint():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+
+def test_enforce_constraints():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+    ly.enforce_constraints()
+
+def test_add_penalty():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+
+def test_get_penalties():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly.get_penalties()
+
+def test_parameter_step():
+    ly = layers.Weights((5,3))
+    deltas = {'matrix': be.zeros_like(ly.W())}
+    ly.parameter_step(deltas)
+
+def test_get_base_config():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly.get_base_config()


### PR DESCRIPTION
Adds some basic functionality to save models as HDFStore objects and represent layers and models as metadata configurations.

The models currently consist of layers and weights.  The layer parameters and the weight matrix are saved as DataFrames in the h5 file, and a configuration for the model (mostly metadata for the layers) is also saved as an attribute.

This PR is ready, but there is more to do:
  - reading models from saved files
  - including state parameters from fitting into a saved model (should they go into the model itself?), e.g. optimizers
  - tests


