### PR TITLE
Layer lists

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -97,7 +97,7 @@ Batch<br />Serves up minibatches from an HDFStore.<br />The validation set is ta
 ### \_\_init\_\_
 ```py
 
-def __init__(self, filename, key, batch_size, train_fraction=0.9, transform=<function float_tensor at 0x11d5d9598>)
+def __init__(self, filename, key, batch_size, train_fraction=0.9, transform=<function float_tensor at 0x1164cf6a8>)
 
 ```
 

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -1,0 +1,21 @@
+# Documentation for Constraints (constraints.py)
+
+## functions
+
+### non\_negative
+```py
+
+def non_negative(tensor)
+
+```
+
+
+
+### non\_positive
+```py
+
+def non_positive(tensor)
+
+```
+
+

--- a/docs/hidden.md
+++ b/docs/hidden.md
@@ -38,6 +38,18 @@ def deterministic_step(self, vis, beta=None)
 Perform a single deterministic (maximum probability) update.<br />v -> update h distribution -> h -> update v distribution -> v'<br /><br />Args:<br /> ~ vis (batch_size, num_visible): Observed visible units.<br /> ~ beta (optional, (batch_size, 1)): Inverse temperatures.<br /><br />Returns:<br /> ~ tensor: New visible units (v').
 
 
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get a configuration for the model.<br /><br />Notes:<br /> ~ Includes metadata on the layers.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the model.
+
+
 ### gradient
 ```py
 
@@ -156,6 +168,46 @@ def random(self, vis)
 
 
 Generate a random sample with the same shape,<br />and of the same type, as the visible units.<br /><br />Args:<br /> ~ vis: The visible units.<br /><br />Returns:<br /> ~ tensor: Random sample with same shape as vis.
+
+
+### save
+```py
+
+def save(self, store)
+
+```
+
+
+
+Save a model to an open HDFStore.<br /><br />Note:<br /> ~ Performs an IO operation.<br /><br />Args:<br /> ~ store (pandas.HDFStore)<br /><br />Returns:<br /> ~ None
+
+
+
+
+## class State
+A State is a list of tensors that contains the states of the units<br />described by a model.<br /><br />For a model with L hidden layers, the tensors have shapes<br /><br />shapes = [<br />(num_samples, num_visible),<br />(num_samples, num_hidden_1),<br />            .<br />            .<br />            .<br />(num_samples, num_hidden_L)<br />]
+### \_\_init\_\_
+```py
+
+def __init__(self, batch_size, model)
+
+```
+
+
+
+Create a randomly initialized State object.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_visible)): observed visible units<br /> ~ model (Model): a model object<br /><br />Returns:<br /> ~ state object
+
+
+### set\_layer
+```py
+
+def set_layer(self, values, i)
+
+```
+
+
+
+Set the units of layer i to values.<br /><br />Notes:<br /> ~ Updates layer.units[i] in place.<br /><br />Args:<br /> ~ values (tensor (num_samples, num_units))<br /><br />Returns:<br /> ~ None
 
 
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -47,7 +47,7 @@ def derivatives(self, vis, hid, weights, beta=None)
 
 
 
-Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights (tensor, (num_units, num_connected_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
+Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights list[tensor, (num_units, num_connected_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
 
 
 ### energy
@@ -72,6 +72,30 @@ def enforce_constraints(self)
 
 
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get the configuration dictionary of the Exponential layer.<br /><br />Args:<br /> ~ None:<br /><br />Returns:<br /> ~ configuratiom (dict):
 
 
 ### get\_penalties
@@ -215,7 +239,7 @@ def update(self, scaled_units, weights, beta=None)
 
 
 
-Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights (tensor, (num_connected_units, num_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
+Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights list[tensor, (num_connected_units, num_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
 
 
 
@@ -267,7 +291,7 @@ def derivatives(self, vis, hid, weights, beta=None)
 
 
 
-Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights (tensor, (num_units, num_connected_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
+Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights list[tensor, (num_units, num_connected_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
 
 
 ### energy
@@ -292,6 +316,30 @@ def enforce_constraints(self)
 
 
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get the configuration dictionary of the Bernoulli layer.<br /><br />Args:<br /> ~ None:<br /><br />Returns:<br /> ~ configuratiom (dict):
 
 
 ### get\_penalties
@@ -435,7 +483,7 @@ def update(self, scaled_units, weights, beta=None)
 
 
 
-Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights (tensor, (num_connected_units, num_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
+Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights list[tensor, (num_connected_units, num_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
 
 
 
@@ -487,7 +535,7 @@ def derivatives(self, vis, hid, weights, beta=None)
 
 
 
-Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights (tensor, (num_units, num_connected_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
+Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights list[tensor, (num_units, num_connected_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
 
 
 ### energy
@@ -512,6 +560,30 @@ def enforce_constraints(self)
 
 
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get the configuration dictionary of the Gaussian layer.<br /><br />Args:<br /> ~ None:<br /><br />Returns:<br /> ~ configuratiom (dict):
 
 
 ### get\_penalties
@@ -547,7 +619,7 @@ def log_partition_function(self, phi)
 
 
 
-Compute the logarithm of the partition function of the layer<br />with external field phi.<br /><br />Let u_i and s_i be the intrinsic loc and scale parameters of unit i.<br />Let phi_i = \sum_j W_{ij} y_j, where y is the vector of connected units.<br /><br />Z_i = \int d x_i exp( -(x_i - u_i)^2 / (2 s_i^2) + \phi_i x_i)<br />= exp(b_i u_i + b_i^2 s_i^2 / 2) sqrt(2 pi) s_i<br /><br />log(Z_i) = log(s_i) + phi_i u_i + phi_i^2 s_i^2 / 2<br /><br />Args:<br /> ~ phi (tensor (num_samples, num_units)): external field<br /><br />Returns:<br /> ~ logZ (tensor, num_samples, num_units)): log partition function
+Compute the logarithm of the partition function of the layer<br />with external field phi.<br /><br />Let u_i and s_i be the intrinsic loc and scale parameters of unit i.<br />Let phi_i = \sum_j W_{ij} y_j, where y is the vector of connected units.<br /><br />Z_i = \int d x_i exp( -(x_i - u_i)^2 / (2 s_i^2) + \phi_i x_i)<br />= exp(b_i u_i + b_i^2 s_i^2 / 2) sqrt(2 pi) s_i<br /><br />log(Z_i) = log(s_i) + phi_i u_i + phi_i^2 s_i^2 / 2<br /><br />Args:<br /> ~ phi tensor (num_samples, num_units): external field<br /><br />Returns:<br /> ~ logZ (tensor, num_samples, num_units)): log partition function
 
 
 ### mean
@@ -655,9 +727,13 @@ def update(self, scaled_units, weights, beta=None)
 
 
 
-Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights (tensor, (num_connected_units, num_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
+Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights list[tensor, (num_connected_units, num_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
 
 
+
+
+## class OrderedDict
+Dictionary that remembers insertion order
 
 
 ## class IsingLayer
@@ -707,7 +783,7 @@ def derivatives(self, vis, hid, weights, beta=None)
 
 
 
-Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights (tensor, (num_units, num_connected_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
+Compute the derivatives of the intrinsic layer parameters.<br /><br />Args:<br /> ~ vis (tensor (num_samples, num_units)):<br /> ~  ~ The values of the visible units.<br /> ~ hid list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the hidden units.<br /> ~ weights list[tensor, (num_units, num_connected_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ grad (dict): {param_name: tensor (contains gradient)}
 
 
 ### energy
@@ -732,6 +808,30 @@ def enforce_constraints(self)
 
 
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get the configuration dictionary of the Ising layer.<br /><br />Args:<br /> ~ None:<br /><br />Returns:<br /> ~ configuratiom (dict):
 
 
 ### get\_penalties
@@ -875,7 +975,7 @@ def update(self, scaled_units, weights, beta=None)
 
 
 
-Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units (tensor (num_samples, num_connected_units)):<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights (tensor, (num_connected_units, num_units)):<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
+Update the extrinsic parameters of the layer.<br /><br />Notes:<br /> ~ Modfies layer.ext_params in place.<br /><br />Args:<br /> ~ scaled_units list[tensor (num_samples, num_connected_units)]:<br /> ~  ~ The rescaled values of the connected units.<br /> ~ weights list[tensor, (num_connected_units, num_units)]:<br /> ~  ~ The weights connecting the layers.<br /> ~ beta (tensor (num_samples, 1), optional):<br /> ~  ~ Inverse temperatures.<br /><br />Returns:<br /> ~ None
 
 
 
@@ -978,6 +1078,30 @@ def enforce_constraints(self)
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
 
 
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get the configuration dictionary of the weights layer.<br /><br />Args:<br /> ~ None:<br /><br />Returns:<br /> ~ configuratiom (dict):
+
+
 ### get\_penalties
 ```py
 
@@ -1064,6 +1188,42 @@ def enforce_constraints(self)
 
 
 Apply the contraints to the layer parameters.<br /><br />Note:<br /> ~ Modifies the intrinsic parameters of the layer in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
+### from\_config
+```py
+
+def from_config(config)
+
+```
+
+
+
+Construct the layer from the base configuration.<br /><br />Args:<br /> ~ A dictionary configuration of the layer metadata.<br /><br />Returns:<br /> ~ An object which is a subclass of `Layer`.
+
+
+### get\_base\_config
+```py
+
+def get_base_config(self)
+
+```
+
+
+
+Get a base configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata for the layer.<br /> ~ Includes the base layer data.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
+
+
+### get\_config
+```py
+
+def get_config(self)
+
+```
+
+
+
+Get a full configuration for the layer.<br /><br />Notes:<br /> ~ Encodes metadata on the layer.<br /> ~ Weights are separately retrieved.<br /> ~ Builds the base configuration.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the layer.
 
 
 ### get\_penalties

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,7 @@
 # Documentation for Metrics (metrics.py)
 
 ## class ReconstructionError
+Compute the root-mean-squared error between observations and their<br />reconstructions using minibatches.
 ### \_\_init\_\_
 ```py
 
@@ -10,7 +11,7 @@ def __init__(self)
 
 
 
-Initialize self.  See help(type(self)) for accurate signature.
+Create a ReconstructionError object.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ ReconstructionERror
 
 
 ### reset
@@ -20,6 +21,9 @@ def reset(self)
 
 ```
 
+
+
+Reset the metric to it's initial state.<br /><br />Notes:<br /> ~ Changes norm and mean_square_error in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
 
 
 ### update
@@ -31,6 +35,9 @@ def update(self, minibatch=None, reconstructions=None, **kwargs)
 
 
 
+Update the estimate for the reconstruction error using a batch<br />of observations and a batch of reconstructions.<br /><br />Notes:<br /> ~ Changes norm and mean_square_error in place.<br /><br />Args:<br /> ~ minibatch (tensor (num_samples, num_units))<br /> ~ reconstructions (tensor (num_samples, num))<br /> ~ kwargs: key word arguments<br /> ~  ~ not used, but helpful for looping through metric functions<br /><br />Returns:<br /> ~ None
+
+
 ### value
 ```py
 
@@ -40,9 +47,13 @@ def value(self)
 
 
 
+Get the value of the reconstruction error.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ reconstruction error (float)
+
+
 
 
 ## class EnergyDistance
+Compute the energy distance between two distributions using<br />minibatches of sampled configurations.<br /><br />Szekely, G.J. (2002)<br />E-statistics: The Energy of Statistical Samples.<br />Technical Report BGSU No 02-16.
 ### \_\_init\_\_
 ```py
 
@@ -52,7 +63,7 @@ def __init__(self, downsample=100)
 
 
 
-Initialize self.  See help(type(self)) for accurate signature.
+Create EnergyDistance object.<br /><br />Args:<br /> ~ downsample (int; optional): how many samples to use<br /><br />Returns:<br /> ~ energy distance object
 
 
 ### reset
@@ -62,6 +73,9 @@ def reset(self)
 
 ```
 
+
+
+Reset the metric to it's initial state.<br /><br />Note:<br /> ~ Modifies norm and energy_distance in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
 
 
 ### update
@@ -73,6 +87,9 @@ def update(self, minibatch=None, samples=None, **kwargs)
 
 
 
+Update the estimate for the energy distance using a batch<br />of observations and a batch of fantasy particles.<br /><br />Notes:<br /> ~ Changes norm and energy_distance in place.<br /><br />Args:<br /> ~ minibatch (tensor (num_samples, num_units))<br /> ~ samples (tensor (num_samples, num)): fantasy particles<br /> ~ kwargs: key word arguments<br /> ~  ~ not used, but helpful for looping through metric functions<br /><br />Returns:<br /> ~ None
+
+
 ### value
 ```py
 
@@ -80,11 +97,15 @@ def value(self)
 
 ```
 
+
+
+Get the value of the energy distance.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ energy distance (float)
 
 
 
 
 ## class EnergyZscore
+Samples drawn from a model should have much lower energy<br />than purely random samples. The "energy gap" is the average<br />energy difference between samples from the model and random<br />samples. The "energy z-score" is the energy gap divided by<br />the standard deviation of the energy taken over random<br />samples.
 ### \_\_init\_\_
 ```py
 
@@ -94,7 +115,7 @@ def __init__(self)
 
 
 
-Initialize self.  See help(type(self)) for accurate signature.
+Create an EnergyZscore object.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ energy z-score object
 
 
 ### reset
@@ -106,6 +127,9 @@ def reset(self)
 
 
 
+Reset the metric to it's initial state.<br /><br />Note:<br /> ~ Modifies norm, random_mean, and random_mean_square in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
 ### update
 ```py
 
@@ -115,6 +139,9 @@ def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs)
 
 
 
+Update the estimate for the energy z-score using a batch<br />of observations and a batch of fantasy particles.<br /><br />Notes:<br /> ~ Changes norm, random_mean, and random_mean_square in place.<br /><br />Args:<br /> ~ minibatch (tensor (num_samples, num_units)):<br /> ~  ~ samples from the model<br /> ~ random_samples (tensor (num_samples, num))<br /> ~ amodel (Model): the model<br /> ~ kwargs: key word arguments<br /> ~  ~ not used, but helpful for looping through metric functions<br /><br />Returns:<br /> ~ None
+
+
 ### value
 ```py
 
@@ -122,11 +149,15 @@ def value(self)
 
 ```
 
+
+
+Get the value of the energy z-score.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ energy z-score (float)
 
 
 
 
 ## class EnergyGap
+Samples drawn from a model should have much lower energy<br />than purely random samples. The "energy gap" is the average<br />energy difference between samples from the model and random<br />samples.
 ### \_\_init\_\_
 ```py
 
@@ -136,7 +167,7 @@ def __init__(self)
 
 
 
-Initialize self.  See help(type(self)) for accurate signature.
+Create an EnergyGap object.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ energy gap object
 
 
 ### reset
@@ -148,6 +179,9 @@ def reset(self)
 
 
 
+Reset the metric to it's initial state.<br /><br />Note:<br /> ~ Modifies norm and energy_gap in place.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ None
+
+
 ### update
 ```py
 
@@ -157,6 +191,9 @@ def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs)
 
 
 
+Update the estimate for the energy gap using a batch<br />of observations and a batch of fantasy particles.<br /><br />Notes:<br /> ~ Changes norm and energy_gap in place.<br /><br />Args:<br /> ~ minibatch (tensor (num_samples, num_units)):<br /> ~  ~ samples from the model<br /> ~ random_samples (tensor (num_samples, num))<br /> ~ amodel (Model): the model<br /> ~ kwargs: key word arguments<br /> ~  ~ not used, but helpful for looping through metric functions<br /><br />Returns:<br /> ~ None
+
+
 ### value
 ```py
 
@@ -164,6 +201,9 @@ def value(self)
 
 ```
 
+
+
+Get the value of the energy gap.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ energy gap (float)
 
 
 

--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -5,7 +5,7 @@ StochasticGradientDescent<br />Basic algorithm of gradient descent with minibatc
 ### \_\_init\_\_
 ```py
 
-def __init__(self, model, stepsize=0.001, scheduler=<paysage.optimizers.PowerLawDecay object at 0x11db36518>, tolerance=0.001)
+def __init__(self, model, stepsize=0.001, scheduler=<paysage.optimizers.PowerLawDecay object at 0x116d50a90>, tolerance=0.001)
 
 ```
 
@@ -168,7 +168,7 @@ def increment(self, epoch)
 ### \_\_init\_\_
 ```py
 
-def __init__(self, scheduler=<paysage.optimizers.PowerLawDecay object at 0x11dbb4c88>, tolerance=0.001)
+def __init__(self, scheduler=<paysage.optimizers.PowerLawDecay object at 0x116d50a20>, tolerance=0.001)
 
 ```
 
@@ -217,7 +217,7 @@ Momentum<br />Stochastic gradient descent with momentum.<br />Qian, N. (1999).<b
 ### \_\_init\_\_
 ```py
 
-def __init__(self, model, stepsize=0.001, momentum=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x11db365c0>, tolerance=1e-06)
+def __init__(self, model, stepsize=0.001, momentum=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x116d50b38>, tolerance=1e-06)
 
 ```
 
@@ -251,7 +251,7 @@ RMSProp<br />Geoffrey Hinton's Coursera Course Lecture 6e
 ### \_\_init\_\_
 ```py
 
-def __init__(self, model, stepsize=0.001, mean_square_weight=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x11db36668>, tolerance=1e-06)
+def __init__(self, model, stepsize=0.001, mean_square_weight=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x116d50be0>, tolerance=1e-06)
 
 ```
 
@@ -285,7 +285,7 @@ ADAM<br />Adaptive Moment Estimation algorithm.<br />Kingma, D. P., & Ba, J. L. 
 ### \_\_init\_\_
 ```py
 
-def __init__(self, model, stepsize=0.001, mean_weight=0.9, mean_square_weight=0.999, scheduler=<paysage.optimizers.PowerLawDecay object at 0x11db36710>, tolerance=1e-06)
+def __init__(self, model, stepsize=0.001, mean_weight=0.9, mean_square_weight=0.999, scheduler=<paysage.optimizers.PowerLawDecay object at 0x116d50c88>, tolerance=1e-06)
 
 ```
 

--- a/docs/penalties.md
+++ b/docs/penalties.md
@@ -1,0 +1,100 @@
+# Documentation for Penalties (penalties.py)
+
+## class log_penalty
+### \_\_init\_\_
+```py
+
+def __init__(self, penalty)
+
+```
+
+
+
+Initialize self.  See help(type(self)) for accurate signature.
+
+
+### grad
+```py
+
+def grad(self, tensor)
+
+```
+
+
+
+### value
+```py
+
+def value(self, tensor)
+
+```
+
+
+
+
+
+## class l1_penalty
+### \_\_init\_\_
+```py
+
+def __init__(self, penalty)
+
+```
+
+
+
+Initialize self.  See help(type(self)) for accurate signature.
+
+
+### grad
+```py
+
+def grad(self, tensor)
+
+```
+
+
+
+### value
+```py
+
+def value(self, tensor)
+
+```
+
+
+
+
+
+## class l2_penalty
+### \_\_init\_\_
+```py
+
+def __init__(self, penalty)
+
+```
+
+
+
+Initialize self.  See help(type(self)) for accurate signature.
+
+
+### grad
+```py
+
+def grad(self, tensor)
+
+```
+
+
+
+### value
+```py
+
+def value(self, tensor)
+
+```
+
+
+
+

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -29,7 +29,8 @@ class Sampler(object):
         else:
             raise ValueError("Unknown method {}".format(self.method))
 
-
+    #TODO: use State
+    # should use hidden.State object
     def randomize_state(self, shape):
         """
            Set up the inital states for each of the Markov Chains.
@@ -39,6 +40,8 @@ class Sampler(object):
         self.state = self.model.random(shape)
         self.has_state = True
 
+    #TODO: use State
+    # should use hidden.State object
     def set_state(self, tensor):
         """
            Set up the inital states for each of the Markov Chains.
@@ -47,6 +50,8 @@ class Sampler(object):
         self.state = be.float_tensor(tensor)
         self.has_state = True
 
+    #TODO: use State
+    # should use hidden.State object
     @classmethod
     def from_batch(cls, amodel, abatch,
                    method='stochastic',
@@ -66,12 +71,16 @@ class SequentialMC(Sampler):
                  method='stochastic'):
         super().__init__(amodel, method=method)
 
+    #TODO: use State
+    # should use hidden.State object
     def update_state(self, steps):
         if not self.has_state:
             raise AttributeError(
                   'You must set the initial state of the Markov Chain')
         self.state = self.updater(self.state, steps)
 
+    #TODO: use State
+    # should use hidden.State object
     def get_state(self):
         return self.state
 
@@ -107,6 +116,8 @@ class DrivenSequentialMC(Sampler):
         self.beta += self.beta_loc
         self.beta += self.beta_scale * be.randn(self.beta_shape)
 
+    #TODO: use State
+    # should use hidden.State object
     def update_state(self, steps):
         if not self.has_state:
             raise AttributeError(
@@ -115,6 +126,8 @@ class DrivenSequentialMC(Sampler):
         self.update_beta()
         self.state = self.updater(self.state, steps, self.beta)
 
+    #TODO: use State
+    # should use hidden.State object
     def get_state(self):
         return self.state
 
@@ -134,16 +147,17 @@ class TrainingMethod(object):
 
 
 class ContrastiveDivergence(TrainingMethod):
-    """ContrastiveDivergence
-       CD-k algorithm for approximate maximum likelihood inference.
+    """
+    ContrastiveDivergence
+    CD-k algorithm for approximate maximum likelihood inference.
 
-       Hinton, Geoffrey E.
-       "Training products of experts by minimizing contrastive divergence."
-       Neural computation 14.8 (2002): 1771-1800.
+    Hinton, Geoffrey E.
+    "Training products of experts by minimizing contrastive divergence."
+    Neural computation 14.8 (2002): 1771-1800.
 
-       Carreira-Perpinan, Miguel A., and Geoffrey Hinton.
-       "On Contrastive Divergence Learning."
-       AISTATS. Vol. 10. 2005.
+    Carreira-Perpinan, Miguel A., and Geoffrey Hinton.
+    "On Contrastive Divergence Learning."
+    AISTATS. Vol. 10. 2005.
 
     """
     def __init__(self, model, abatch, optimizer, sampler, epochs,
@@ -164,6 +178,12 @@ class ContrastiveDivergence(TrainingMethod):
                     v_data = self.batch.get(mode='train')
                 except StopIteration:
                     break
+
+                #TODO: use State
+                # should use hidden.State objects
+                # note that we will need two states
+                # one for the positive phase (with visible units as observed)
+                # one for the negative phase (with visible units sampled from the model)
 
                 # CD resets the sampler from the visible data at each iteration
                 self.sampler.set_state(v_data)
@@ -222,6 +242,13 @@ class PersistentContrastiveDivergence(TrainingMethod):
                     v_data = self.batch.get(mode='train')
                 except StopIteration:
                     break
+
+                #TODO: use State
+                # should use hidden.State objects
+                # note that we will need two states
+                # one for the positive phase (with visible units as observed)
+                # one for the negative phase (with visible units sampled from the model)
+
                 # PCD keeps the sampler from the previous iteration
                 self.sampler.update_state(self.mcsteps)
 
@@ -274,6 +301,9 @@ class ProgressMonitor(object):
                     v_data = self.batch.get(mode='validate')
                 except StopIteration:
                     break
+
+                #TODO: use State
+                # should use hidden.State objects
 
                 # compute the reconstructions
                 sampler.set_state(v_data)

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -304,6 +304,9 @@ class ProgressMonitor(object):
 
                 #TODO: use State
                 # should use hidden.State objects
+                # note that we will need two states
+                # one for the positive phase (with visible units as observed)
+                # one for the fantasy particles (with visible units sampled from the model)
 
                 # compute the reconstructions
                 sampler.set_state(v_data)

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from . import backends as be
 from . import metrics as M
 
+#TODO: should import the State class from hidden.py
+
 # -----  CLASSES ----- #
 
 class Sampler(object):

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -270,6 +270,7 @@ class GaussianLayer(Layer):
         result /= be.broadcast(scale, vis)
         return 0.5 * be.mean(result, axis=1)
 
+    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -349,6 +350,7 @@ class GaussianLayer(Layer):
         be.mix_inplace(be.float_scalar(1-shrinkage), var, be.ones_like(var))
         self.int_params['log_var'] = be.log(var)
 
+    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -383,6 +385,7 @@ class GaussianLayer(Layer):
                                       self.ext_params['mean']
                                       )
 
+    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -554,6 +557,7 @@ class IsingLayer(Layer):
         """
         return -be.dot(data, self.int_params['loc'])
 
+    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -620,6 +624,7 @@ class IsingLayer(Layer):
         """
         pass
 
+    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -650,6 +655,7 @@ class IsingLayer(Layer):
                                     self.ext_params['field']
                                     )
 
+    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -804,6 +810,7 @@ class BernoulliLayer(Layer):
         """
         return -be.dot(data, self.int_params['loc'])
 
+    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -870,6 +877,7 @@ class BernoulliLayer(Layer):
         """
         pass
 
+    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -900,6 +908,7 @@ class BernoulliLayer(Layer):
                                     self.ext_params['field']
                                     )
 
+    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -1054,6 +1063,7 @@ class ExponentialLayer(Layer):
         """
         return be.dot(data, self.int_params['loc'])
 
+    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -1120,6 +1130,7 @@ class ExponentialLayer(Layer):
         """
         pass
 
+    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -1150,6 +1161,7 @@ class ExponentialLayer(Layer):
                                     self.ext_params['rate']
                                     )
 
+    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -387,7 +387,6 @@ class GaussianLayer(Layer):
                                       self.ext_params['mean']
                                       )
 
-    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -395,9 +394,9 @@ class GaussianLayer(Layer):
         Args:
             vis (tensor (num_samples, num_units)):
                 The values of the visible units.
-            hid (tensor (num_samples, num_connected_units)):
+            hid list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the hidden units.
-            weights (tensor, (num_units, num_connected_units)):
+            weights list[tensor, (num_units, num_connected_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -418,12 +417,13 @@ class GaussianLayer(Layer):
         vis - be.broadcast(self.int_params['loc'], vis)
         )
         derivs['log_var'] = -0.5 * be.mean(diff, axis=0)
-        derivs['log_var'] += be.batch_dot(
-                             hid,
-                             be.transpose(weights),
-                             vis,
-                             axis=0
-                             ) / len(vis)
+        for i in range(len(hid)):
+            derivs['log_var'] += be.batch_dot(
+                                 hid[i],
+                                 be.transpose(weights[i]),
+                                 vis,
+                                 axis=0
+                                 ) / len(vis)
         derivs['log_var'] = self.rescale(derivs['log_var'])
 
         be.add_dicts_inplace(derivs, self.get_penalty_gradients())
@@ -658,7 +658,6 @@ class IsingLayer(Layer):
                                     self.ext_params['field']
                                     )
 
-    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -666,9 +665,9 @@ class IsingLayer(Layer):
         Args:
             vis (tensor (num_samples, num_units)):
                 The values of the visible units.
-            hid (tensor (num_samples, num_connected_units)):
+            hid list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the hidden units.
-            weights (tensor, (num_units, num_connected_units)):
+            weights list[tensor, (num_units, num_connected_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -912,7 +911,6 @@ class BernoulliLayer(Layer):
                                     self.ext_params['field']
                                     )
 
-    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -920,9 +918,9 @@ class BernoulliLayer(Layer):
         Args:
             vis (tensor (num_samples, num_units)):
                 The values of the visible units.
-            hid (tensor (num_samples, num_connected_units)):
+            hid list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the hidden units.
-            weights (tensor, (num_units, num_connected_units)):
+            weights list[tensor, (num_units, num_connected_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -1166,7 +1164,6 @@ class ExponentialLayer(Layer):
                                     self.ext_params['rate']
                                     )
 
-    #TODO: hid: list[tensor], weights: list[tensor]
     def derivatives(self, vis, hid, weights, beta=None):
         """
         Compute the derivatives of the intrinsic layer parameters.
@@ -1174,9 +1171,9 @@ class ExponentialLayer(Layer):
         Args:
             vis (tensor (num_samples, num_units)):
                 The values of the visible units.
-            hid (tensor (num_samples, num_connected_units)):
+            hid list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the hidden units.
-            weights (tensor, (num_units, num_connected_units)):
+            weights list[tensor, (num_units, num_connected_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -350,7 +350,6 @@ class GaussianLayer(Layer):
         be.mix_inplace(be.float_scalar(1-shrinkage), var, be.ones_like(var))
         self.int_params['log_var'] = be.log(var)
 
-    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -359,9 +358,9 @@ class GaussianLayer(Layer):
             Modfies layer.ext_params in place.
 
         Args:
-            scaled_units (tensor (num_samples, num_connected_units)):
+            scaled_units list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the connected units.
-            weights (tensor, (num_connected_units, num_units)):
+            weights list[tensor, (num_connected_units, num_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -370,7 +369,10 @@ class GaussianLayer(Layer):
             None
 
         """
-        self.ext_params['mean'] = be.dot(scaled_units, weights)
+        self.ext_params['mean'] = be.dot(scaled_units[0], weights[0])
+        for i in range(1, len(weights)):
+            self.ext_params['mean'] += be.dot(scaled_units[i], weights[i])
+
         if beta is not None:
             self.ext_params['mean'] *= be.broadcast(
                                        beta,
@@ -623,7 +625,6 @@ class IsingLayer(Layer):
         """
         pass
 
-    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -632,9 +633,9 @@ class IsingLayer(Layer):
             Modfies layer.ext_params in place.
 
         Args:
-            scaled_units (tensor (num_samples, num_connected_units)):
+            scaled_units list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the connected units.
-            weights (tensor, (num_connected_units, num_units)):
+            weights list[tensor, (num_connected_units, num_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -643,7 +644,10 @@ class IsingLayer(Layer):
             None
 
         """
-        self.ext_params['field'] = be.dot(scaled_units, weights)
+        self.ext_params['field'] = be.dot(scaled_units[0], weights[0])
+        for i in range(1, len(weights)):
+            self.ext_params['field'] += be.dot(scaled_units[i], weights[i])
+
         if beta is not None:
             self.ext_params['field'] *= be.broadcast(
                                         beta,
@@ -875,7 +879,6 @@ class BernoulliLayer(Layer):
         """
         pass
 
-    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -884,9 +887,9 @@ class BernoulliLayer(Layer):
             Modfies layer.ext_params in place.
 
         Args:
-            scaled_units (tensor (num_samples, num_connected_units)):
+            scaled_units list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the connected units.
-            weights (tensor, (num_connected_units, num_units)):
+            weights list[tensor, (num_connected_units, num_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -895,7 +898,10 @@ class BernoulliLayer(Layer):
             None
 
         """
-        self.ext_params['field'] = be.dot(scaled_units, weights)
+        self.ext_params['field'] = be.dot(scaled_units[0], weights[0])
+        for i in range(1, len(weights)):
+            self.ext_params['field'] += be.dot(scaled_units[i], weights[i])
+
         if beta is not None:
             self.ext_params['field'] *= be.broadcast(
                                         beta,
@@ -1127,7 +1133,6 @@ class ExponentialLayer(Layer):
         """
         pass
 
-    #TODO: scaled_units: list[tensor], weights: list[tensor]
     def update(self, scaled_units, weights, beta=None):
         """
         Update the extrinsic parameters of the layer.
@@ -1136,9 +1141,9 @@ class ExponentialLayer(Layer):
             Modfies layer.ext_params in place.
 
         Args:
-            scaled_units (tensor (num_samples, num_connected_units)):
+            scaled_units list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the connected units.
-            weights (tensor, (num_connected_units, num_units)):
+            weights list[tensor, (num_connected_units, num_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -1147,7 +1152,10 @@ class ExponentialLayer(Layer):
             None
 
         """
-        self.ext_params['rate'] = -be.dot(scaled_units, weights)
+        self.ext_params['rate'] = -be.dot(scaled_units[0], weights[0])
+        for i in range(1, len(weights)):
+            self.ext_params['rate'] -= be.dot(scaled_units[i], weights[i])
+
         if beta is not None:
             self.ext_params['rate'] *= be.broadcast(
                                         beta,

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -270,7 +270,6 @@ class GaussianLayer(Layer):
         result /= be.broadcast(scale, vis)
         return 0.5 * be.mean(result, axis=1)
 
-    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -285,13 +284,14 @@ class GaussianLayer(Layer):
         log(Z_i) = log(s_i) + phi_i u_i + phi_i^2 s_i^2 / 2
 
         Args:
-            phi (tensor (num_samples, num_units)): external field
+            phi tensor (num_samples, num_units): external field
 
         Returns:
             logZ (tensor, num_samples, num_units)): log partition function
 
         """
         scale = be.exp(self.int_params['log_var'])
+
 
         logZ = be.broadcast(self.int_params['loc'], phi) * phi
         logZ += be.broadcast(scale, phi) * be.square(phi)
@@ -557,7 +557,6 @@ class IsingLayer(Layer):
         """
         return -be.dot(data, self.int_params['loc'])
 
-    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -810,7 +809,6 @@ class BernoulliLayer(Layer):
         """
         return -be.dot(data, self.int_params['loc'])
 
-    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer
@@ -1063,7 +1061,6 @@ class ExponentialLayer(Layer):
         """
         return be.dot(data, self.int_params['loc'])
 
-    #TODO: phi: list[tensor]
     def log_partition_function(self, phi):
         """
         Compute the logarithm of the partition function of the layer

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -16,6 +16,7 @@ class ReconstructionError(object):
         self.mean_square_error = 0
         self.norm = 0
 
+    #TODO: use State objects instead of tensors
     def update(self, minibatch=None, reconstructions=None, **kwargs):
         self.norm += len(minibatch)
         self.mean_square_error += be.tsum((minibatch - reconstructions)**2)
@@ -40,11 +41,11 @@ class EnergyDistance(object):
         self.energy_distance = 0
         self.norm = 0
 
+    #TODO: use State objects instead of tensors
     def update(self, minibatch=None, samples=None, **kwargs):
         self.norm += 1
         self.energy_distance += be.fast_energy_distance(minibatch, samples,
                                                      self.downsample)
-
     def value(self):
         if self.norm:
             return self.energy_distance / self.norm
@@ -64,6 +65,7 @@ class EnergyGap(object):
         self.energy_gap = 0
         self.norm = 0
 
+    #TODO: use State objects instead of tensors
     def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs):
         self.norm += 1
         self.energy_gap += be.mean(amodel.marginal_free_energy(minibatch))
@@ -90,6 +92,7 @@ class EnergyZscore(object):
         self.random_mean = 0
         self.random_mean_square = 0
 
+    #TODO: use State objects instead of tensors
     def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs):
         self.data_mean += be.mean(amodel.marginal_free_energy(minibatch))
         self.random_mean +=  be.mean(amodel.marginal_free_energy(random_samples))

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -159,7 +159,7 @@ class EnergyDistance(object):
             None
 
         Returns:
-            reconstruction error (float)
+            energy distance (float)
 
         """
         if self.norm:
@@ -169,24 +169,83 @@ class EnergyDistance(object):
 
 
 class EnergyGap(object):
+    """
+    Samples drawn from a model should have much lower energy
+    than purely random samples. The "energy gap" is the average
+    energy difference between samples from the model and random
+    samples.
+
+    """
 
     name = 'EnergyGap'
 
     def __init__(self):
+        """
+        Create an EnergyGap object.
+
+        Args:
+            None
+
+        Returns:
+            energy gap object
+
+        """
         self.energy_gap = 0
         self.norm = 0
 
     def reset(self):
+        """
+        Reset the metric to it's initial state.
+
+        Note:
+            Modifies norm and energy_gap in place.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
         self.energy_gap = 0
         self.norm = 0
 
     #TODO: use State objects instead of tensors
     def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs):
+        """
+        Update the estimate for the energy distance using a batch
+        of observations and a batch of fantasy particles.
+
+        Notes:
+            Changes norm and energy_gap in place.
+
+        Args:
+            minibatch (tensor (num_samples, num_units)):
+                samples from the model
+            random_samples (tensor (num_samples, num))
+            amodel (Model): the model
+            kwargs: key word arguments
+                not used, but helpful for looping through metric functions
+
+        Returns:
+            None
+
+        """
         self.norm += 1
         self.energy_gap += be.mean(amodel.marginal_free_energy(minibatch))
         self.energy_gap -= be.mean(amodel.marginal_free_energy(random_samples))
 
     def value(self):
+        """
+        Get the value of the energy gap.
+
+        Args:
+            None
+
+        Returns:
+            energy gap (float)
+
+        """
         if self.norm:
             return self.energy_gap / self.norm
         else:

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -84,24 +84,84 @@ class ReconstructionError(object):
 
 
 class EnergyDistance(object):
+    """
+    Compute the energy distance between two distributions using
+    minibatches of sampled configurations.
+
+    Szekely, G.J. (2002)
+    E-statistics: The Energy of Statistical Samples.
+    Technical Report BGSU No 02-16.
+
+    """
 
     name = 'EnergyDistance'
 
     def __init__(self, downsample=100):
+        """
+        Create EnergyDistance object.
+
+        Args:
+            downsample (int; optional): how many samples to use
+
+        Returns:
+            energy distance object
+
+        """
         self.energy_distance = 0
         self.norm = 0
         self.downsample = 100
 
     def reset(self):
+        """
+        Reset the metric to it's initial state.
+
+        Note:
+            Modifies norm and energy_distance in place.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
         self.energy_distance = 0
         self.norm = 0
 
     #TODO: use State objects instead of tensors
     def update(self, minibatch=None, samples=None, **kwargs):
+        """
+        Update the estimate for the energy distance using a batch
+        of observations and a batch of fantasy particles.
+
+        Notes:
+            Changes norm and energy_distance in place.
+
+        Args:
+            minibatch (tensor (num_samples, num_units))
+            samples (tensor (num_samples, num)): fantasy particles
+            kwargs: key word arguments
+                not used, but helpful for looping through metric functions
+
+        Returns:
+            None
+
+        """
         self.norm += 1
         self.energy_distance += be.fast_energy_distance(minibatch, samples,
                                                      self.downsample)
+
     def value(self):
+        """
+        Get the value of the energy distance.
+
+        Args:
+            None
+
+        Returns:
+            reconstruction error (float)
+
+        """
         if self.norm:
             return self.energy_distance / self.norm
         else:

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -5,23 +5,78 @@ from . import backends as be
 
 
 class ReconstructionError(object):
+    """
+    Compute the root-mean-squared error between observations and their
+    reconstructions using minibatches.
+
+    """
 
     name = 'ReconstructionError'
 
     def __init__(self):
+        """
+        Create a ReconstructionError object.
+
+        Args:
+            None
+
+        Returns:
+            ReconstructionERror
+
+        """
         self.mean_square_error = 0
         self.norm = 0
 
     def reset(self):
+        """
+        Reset the metric to it's initial state.
+
+        Notes:
+            Changes norm and mean_square_error in place.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
         self.mean_square_error = 0
         self.norm = 0
 
     #TODO: use State objects instead of tensors
     def update(self, minibatch=None, reconstructions=None, **kwargs):
+        """
+        Update the estimate for the reconstruction error using a batch
+        of observations and a batch of reconstructions.
+
+        Notes:
+            Changes norm and mean_square_error in place.
+
+        Args:
+            minibatch (tensor (num_samples, num_units))
+            reconstructions (tensor (num_samples, num))
+            kwargs: key word arguments
+                not used, but helpful for looping through metric functions
+
+        Returns:
+            None
+
+        """
         self.norm += len(minibatch)
         self.mean_square_error += be.tsum((minibatch - reconstructions)**2)
 
     def value(self):
+        """
+        Get the value of the reconstruction error.
+
+        Args:
+            None
+
+        Returns:
+            reconstruction error (float)
+
+        """
         if self.norm:
             return math.sqrt(self.mean_square_error / self.norm)
         else:

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -213,7 +213,7 @@ class EnergyGap(object):
     #TODO: use State objects instead of tensors
     def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs):
         """
-        Update the estimate for the energy distance using a batch
+        Update the estimate for the energy gap using a batch
         of observations and a batch of fantasy particles.
 
         Notes:
@@ -253,26 +253,87 @@ class EnergyGap(object):
 
 
 class EnergyZscore(object):
+    """
+    Samples drawn from a model should have much lower energy
+    than purely random samples. The "energy gap" is the average
+    energy difference between samples from the model and random
+    samples. The "energy z-score" is the energy gap divided by
+    the standard deviation of the energy taken over random
+    samples.
+
+    """
 
     name = 'EnergyZscore'
 
     def __init__(self):
+        """
+        Create an EnergyZscore object.
+
+        Args:
+            None
+
+        Returns:
+            energy z-score object
+
+        """
         self.data_mean = 0
         self.random_mean = 0
         self.random_mean_square = 0
 
     def reset(self):
+        """
+        Reset the metric to it's initial state.
+
+        Note:
+            Modifies norm, random_mean, and random_mean_square in place.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
         self.data_mean = 0
         self.random_mean = 0
         self.random_mean_square = 0
 
     #TODO: use State objects instead of tensors
     def update(self, minibatch=None, random_samples=None, amodel=None, **kwargs):
+        """
+        Update the estimate for the energy z-score using a batch
+        of observations and a batch of fantasy particles.
+
+        Notes:
+            Changes norm, random_mean, and random_mean_square in place.
+
+        Args:
+            minibatch (tensor (num_samples, num_units)):
+                samples from the model
+            random_samples (tensor (num_samples, num))
+            amodel (Model): the model
+            kwargs: key word arguments
+                not used, but helpful for looping through metric functions
+
+        Returns:
+            None
+
+        """
         self.data_mean += be.mean(amodel.marginal_free_energy(minibatch))
         self.random_mean +=  be.mean(amodel.marginal_free_energy(random_samples))
         self.random_mean_square +=  be.mean(amodel.marginal_free_energy(random_samples)**2)
 
     def value(self):
+        """
+        Get the value of the energy z-score.
+
+        Args:
+            None
+
+        Returns:
+            energy z-score (float)
+
+        """
         if self.random_mean_square:
             return (self.data_mean - self.random_mean) / math.sqrt(self.random_mean_square)
         else:

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -393,6 +393,17 @@ class Model(object):
             new_vis = self.deterministic_step(new_vis, beta)
         return new_vis
 
+    #TODO: use State
+    # currently, gradients are computed using the mean of the hidden units
+    # conditioned on the value of the visible units
+    # this will not work for deep models, because we cannot compute
+    # the means for models with more than 1 hidden layer
+    # therefore, the gradients need to be computed from samples
+    # of all of the visible and hidden layer units (i.e., States)
+    #
+    # Args should be:
+    # data (State): observed visible units and sampled hidden units
+    # model (State): visible and hidden units sampled from the model
     def gradient(self, vdata, vmodel):
         """
         Compute the gradient of the model parameters.
@@ -524,6 +535,11 @@ class Model(object):
         for i in range(self.num_layers - 1):
             self.weights[i].parameter_step(deltas['weights'][i])
 
+    # TODO: use State
+    # Args should be:
+    # data (state): values of all the units
+    # this should be the easiest function to update
+    # also, it isn't really used anywhere right now
     def joint_energy(self, vis, hid):
         """
         Compute the joint energy of the model.
@@ -543,6 +559,10 @@ class Model(object):
             energy += self.weights[i].energy(vis, hid)
         return energy
 
+    # TODO: not sure what to do about this function for deep models
+    # i think it should be implemented only for models with 1 hidden layer
+    # could still take in a State object
+    # but should assert self.num_layers == 2
     def marginal_free_energy(self, vis):
         """
         Compute the marginal free energy of the model.

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -165,11 +165,19 @@ class Model(object):
 
         """
         i = 0
-        self.layers[i+1].update(self.layers[i].rescale(vis),
-                                self.weights[i].W(), beta)
+
+        self.layers[i+1].update(
+        [self.layers[i].rescale(vis)],
+        [self.weights[i].W()],
+        beta)
+
         hid = self.layers[i+1].sample_state()
-        self.layers[i].update(self.layers[i+1].rescale(hid),
-                              self.weights[i].W_T(), beta)
+
+        self.layers[i].update(
+        [self.layers[i+1].rescale(hid)],
+        [self.weights[i].W_T()],
+        beta)
+
         return self.layers[i].sample_state()
 
     def markov_chain(self, vis, n, beta=None):
@@ -205,11 +213,19 @@ class Model(object):
 
         """
         i = 0
-        self.layers[i+1].update(self.layers[i].rescale(vis),
-                                self.weights[i].W(), beta)
+
+        self.layers[i+1].update(
+        [self.layers[i].rescale(vis)],
+        [self.weights[i].W()],
+        beta)
+
         hid = self.layers[i+1].mean()
-        self.layers[i].update(self.layers[i+1].rescale(hid),
-                              self.weights[i].W_T(), beta)
+
+        self.layers[i].update(
+        [self.layers[i+1].rescale(hid)],
+        [self.weights[i].W_T()],
+        beta)
+
         return self.layers[i].mean()
 
     def mean_field_iteration(self, vis, n, beta=None):
@@ -245,11 +261,19 @@ class Model(object):
 
         """
         i = 0
-        self.layers[i+1].update(self.layers[i].rescale(vis),
-                                  self.weights[i].W(), beta)
+
+        self.layers[i+1].update(
+        [self.layers[i].rescale(vis)],
+        [self.weights[i].W()],
+        beta)
+
         hid = self.layers[i+1].mode()
-        self.layers[i].update(self.layers[i+1].rescale(hid),
-                              self.weights[i].W_T(), beta)
+
+        self.layers[i].update(
+        [self.layers[i+1].rescale(hid)],
+        [self.weights[i].W_T()],
+        beta)
+
         return self.layers[i].mode()
 
     def deterministic_iteration(self, vis, n, beta=None):
@@ -320,7 +344,10 @@ class Model(object):
         vdata_scaled = self.layers[i].rescale(vdata)
 
         # 2. Update the hidden layer
-        self.layers[i+1].update(vdata_scaled, self.weights[0].W())
+        self.layers[i+1].update(
+        [vdata_scaled],
+        [self.weights[0].W()]
+        )
 
         # 3. Compute the mean of the hidden layer
         hid = self.layers[i+1].mean()
@@ -343,7 +370,10 @@ class Model(object):
         vmodel_scaled = self.layers[i].rescale(vmodel)
 
         # 2. Update the hidden layer
-        self.layers[i+1].update(vmodel_scaled, self.weights[0].W())
+        self.layers[i+1].update(
+        [vmodel_scaled],
+        [self.weights[0].W()]
+        )
 
         # 3. Compute the mean of the hidden layer
         hid = self.layers[i+1].mean()

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -99,7 +99,7 @@ class Model(object):
                                 self.weights[i].W(), beta)
         hid = self.layers[i+1].sample_state()
         self.layers[i].update(self.layers[i+1].rescale(hid),
-                              be.transpose(self.weights[i].W()), beta)
+                              self.weights[i].W_T(), beta)
         return self.layers[i].sample_state()
 
     def markov_chain(self, vis, n, beta=None):
@@ -139,7 +139,7 @@ class Model(object):
                                 self.weights[i].W(), beta)
         hid = self.layers[i+1].mean()
         self.layers[i].update(self.layers[i+1].rescale(hid),
-                              be.transpose(self.weights[i].W()), beta)
+                              self.weights[i].W_T(), beta)
         return self.layers[i].mean()
 
     def mean_field_iteration(self, vis, n, beta=None):
@@ -179,7 +179,7 @@ class Model(object):
                                   self.weights[i].W(), beta)
         hid = self.layers[i+1].mode()
         self.layers[i].update(self.layers[i+1].rescale(hid),
-                              be.transpose(self.weights[i].W()), beta)
+                              self.weights[i].W_T(), beta)
         return self.layers[i].mode()
 
     def deterministic_iteration(self, vis, n, beta=None):
@@ -244,8 +244,6 @@ class Model(object):
         'weights': [None for w in self.weights]
         }
 
-        W_transpose = be.transpose(self.weights[0].W())
-
         # POSITIVE PHASE (using observed)
 
         # 1. Scale vdata
@@ -264,7 +262,7 @@ class Model(object):
         grad['layers'][i] = self.layers[i].derivatives(vdata, hid_scaled,
                                                self.weights[0].W())
         grad['layers'][i+1] = self.layers[i+1].derivatives(hid, vdata_scaled,
-                                                           W_transpose)
+                                               self.weights[0].W_T())
 
         grad['weights'][i] = self.weights[i].derivatives(vdata_scaled,
                                                          hid_scaled)
@@ -293,7 +291,7 @@ class Model(object):
                                   self.layers[i+1].derivatives(
                                                    hid,
                                                    vmodel_scaled,
-                                                   W_transpose))
+                                                   self.weights[0].W_T()))
 
         be.subtract_dicts_inplace(grad['weights'][i],
                                   self.weights[i].derivatives(

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -192,6 +192,22 @@ class Model(object):
         """
         return self.layers[0].random(vis)
 
+    #TODO: use State
+    # currently, this method takes in a single tensor (vis)
+    # and outputs a single tensor (new vis)
+    # the hidden units are only treated implicitly
+    #
+    # this method should take in a State (with the units of all of the layers)
+    # and output a new State (with the updated units of all of the layers)
+    #
+    # this could be done in with the following steps:
+    # 1) update the extrinsic parameters of the odd layers
+    # 2) sample new configurations for the odd layers
+    # 3) update the extrinsic parameters of the even layers
+    # 4) sample new configurations for the even layers
+    #
+    # either, this could return a new State object (which involves a copy)
+    # or, it could mutate the values of the State tensors in place
     def mcstep(self, vis, beta=None):
         """
         Perform a single Gibbs sampling update.
@@ -221,6 +237,9 @@ class Model(object):
 
         return self.layers[i].sample_state()
 
+    # TODO: use State
+    # this function is just a repeated application of mcstep
+    # so it should be changed to operate on State objects too
     def markov_chain(self, vis, n, beta=None):
         """
         Perform multiple Gibbs sampling steps.
@@ -240,6 +259,22 @@ class Model(object):
             new_vis = self.mcstep(new_vis, beta)
         return new_vis
 
+    #TODO: use State
+    # currently, this method takes in a single tensor (vis)
+    # and outputs a single tensor (new vis)
+    # the hidden units are only treated implicitly
+    #
+    # this method should take in a State (with the units of all of the layers)
+    # and output a new State (with the updated units of all of the layers)
+    #
+    # this could be done in with the following steps:
+    # 1) update the extrinsic parameters of the odd layers
+    # 2) compute the mean of the odd layers
+    # 3) update the extrinsic parameters of the even layers
+    # 4) compute the mean of the even layers
+    #
+    # either, this could return a new State object (which involves a copy)
+    # or, it could mutate the values of the State tensors in place
     def mean_field_step(self, vis, beta=None):
         """
         Perform a single mean-field update.
@@ -269,6 +304,9 @@ class Model(object):
 
         return self.layers[i].mean()
 
+    # TODO: use State
+    # this function is just a repeated application of mean_field_step
+    # so it should be changed to operate on State objects too
     def mean_field_iteration(self, vis, n, beta=None):
         """
         Perform multiple mean-field updates.
@@ -288,6 +326,22 @@ class Model(object):
             new_vis = self.mean_field_step(new_vis, beta)
         return new_vis
 
+    #TODO: use State
+    # currently, this method takes in a single tensor (vis)
+    # and outputs a single tensor (new vis)
+    # the hidden units are only treated implicitly
+    #
+    # this method should take in a State (with the units of all of the layers)
+    # and output a new State (with the updated units of all of the layers)
+    #
+    # this could be done in with the following steps:
+    # 1) update the extrinsic parameters of the odd layers
+    # 2) compute the mode of the odd layers
+    # 3) update the extrinsic parameters of the even layers
+    # 4) compute the mode of the even layers
+    #
+    # either, this could return a new State object (which involves a copy)
+    # or, it could mutate the values of the State tensors in place
     def deterministic_step(self, vis, beta=None):
         """
         Perform a single deterministic (maximum probability) update.
@@ -317,6 +371,9 @@ class Model(object):
 
         return self.layers[i].mode()
 
+    # TODO: use State
+    # this function is just a repeated application of deterministic_step
+    # so it should be changed to operate on State objects too
     def deterministic_iteration(self, vis, n, beta=None):
         """
         Perform multiple deterministic (maximum probability) updates.

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -1,3 +1,6 @@
+import os
+import pandas
+
 from .. import layers
 from .. import backends as be
 from ..models.initialize import init_hidden as init
@@ -103,17 +106,55 @@ class Model(object):
         # the layers are stored in a list with the visible units
         # as the zeroth element
         self.layers = layer_list
-        self.len = len(self.layers)
+        self.num_layers = len(self.layers)
 
-        assert self.len == 2,\
+        assert self.num_layers == 2,\
         "Only models with 2 layers are currently supported"
 
         # adjacent layers are connected by weights
         # therefore, if there are len(layers) = n then len(weights) = n - 1
         self.weights = [
         layers.Weights((self.layers[i].len, self.layers[i+1].len))
-        for i in range(len(self.layers) - 1)
+        for i in range(self.num_layers - 1)
         ]
+
+    def get_config(self):
+        """
+        Get a configuration for the model.
+
+        Notes:
+            Includes metadata on the layers.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary configuration for the model.
+
+        """
+        config = {
+        "model type": "RBM",
+        "layers": [ly.get_config() for ly in self.layers],
+        "layer_types": ["visible", "hidden"],
+        }
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        """
+        Build a model from the configuration.
+
+        Args:
+            A dictionary configuration of the model metadata.
+
+        Returns:
+            An instance of the model.
+
+        """
+        layer_list = []
+        for ly in config["layers"]:
+            layer_list.append(layers.Layer.from_config(ly))
+        return cls(layer_list)
 
     def initialize(self, data, method='hinton'):
         """
@@ -421,9 +462,9 @@ class Model(object):
             None
 
         """
-        for i in range(len(self.layers)):
+        for i in range(self.num_layers):
             self.layers[i].parameter_step(deltas['layers'][i])
-        for i in range(len(self.weights)):
+        for i in range(self.num_layers - 1):
             self.weights[i].parameter_step(deltas['weights'][i])
 
     def joint_energy(self, vis, hid):
@@ -468,3 +509,46 @@ class Model(object):
         energy += self.layers[i].energy(vis)
         energy -= be.tsum(log_Z_hidden, axis=1)
         return energy
+
+    def save(self, store):
+        """
+        Save a model to an open HDFStore.
+
+        Note:
+            Performs an IO operation.
+
+        Args:
+            store (pandas.HDFStore)
+
+        Returns:
+            None
+
+        """
+        # save the config as an attribute
+        config = self.get_config()
+        store.put('model', pandas.DataFrame())
+        store.get_storer('model').attrs.config = config
+        # save the weights
+        for i in range(self.num_layers - 1):
+            df_weights = pandas.DataFrame(
+                            be.to_numpy_array(self.weights[i].W())
+                         )
+            store.put('weights/weights_'+str(i), df_weights)
+        for i in range(len(self.layers)):
+            layer_type = config["layer_types"][i]
+            layer = config["layers"][i]
+            layer_key = os.path.join('layers', layer_type)
+            # intrinsic params
+            intrinsics = layer["intrinsic"]
+            for ip in intrinsics:
+                df_params = pandas.DataFrame(
+                            be.to_numpy_array(self.layers[i].int_params[ip])
+                         )
+                store.put(os.path.join(layer_key,'intrinsic', ip), df_params)
+            # extrinsic params
+            extrinsics = layer["extrinsic"]
+            for ep in extrinsics:
+                df_params = pandas.DataFrame(
+                            be.to_numpy_array(self.layers[i].ext_params[ep])
+                         )
+                store.put(os.path.join(layer_key,'extrinsic', ep), df_params)

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -23,21 +23,21 @@ class State(object):
     ]
 
     """
-    def __init__(self, batch_size, layers):
+    def __init__(self, batch_size, model):
         """
         Create a randomly initialized State object.
 
         Args:
             vis (tensor (num_samples, num_visible)): observed visible units
-            layers (list): list of layers objects
+            model (Model): a model object
 
         Returns:
             state object
 
         """
-        self.shapes = [(batch_size, l.len) for l in layers]
+        self.shapes = [(batch_size, l.len) for l in model.layers]
         self.units = [layers[i].random(self.shapes[i])
-                      for i in range(len(layers))]
+                      for i in range(model.num_layers)]
 
     def set_layer(self, values, i):
         """
@@ -56,20 +56,20 @@ class State(object):
         self.units[i] = values
 
     @classmethod
-    def from_visible(cls, vis, layers):
+    def from_visible(cls, vis, model):
         """
         Create a state object with given visible unit values.
 
         Args:
             vis (tensor (num_samples, num_visible))
-            layers (list): list of layers objects
+            model (Model): a model object
 
         Returns:
             state object
 
         """
         batch_size = be.shape(vis)[0]
-        state = cls(batch_size, layers)
+        state = cls(batch_size, model)
         state.set_visible(vis, 0)
         return state
 

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -356,10 +356,15 @@ class Model(object):
         hid_scaled = self.layers[i+1].rescale(hid)
 
         # 5. Compute the gradients
-        grad['layers'][i] = self.layers[i].derivatives(vdata, hid_scaled,
-                                               self.weights[0].W())
-        grad['layers'][i+1] = self.layers[i+1].derivatives(hid, vdata_scaled,
-                                               self.weights[0].W_T())
+        grad['layers'][i] = self.layers[i].derivatives(vdata,
+                                           [hid_scaled],
+                                           [self.weights[0].W()]
+                                           )
+
+        grad['layers'][i+1] = self.layers[i+1].derivatives(hid,
+                                               [vdata_scaled],
+                                               [self.weights[0].W_T()]
+                                               )
 
         grad['weights'][i] = self.weights[i].derivatives(vdata_scaled,
                                                          hid_scaled)
@@ -385,13 +390,16 @@ class Model(object):
         be.subtract_dicts_inplace(grad['layers'][i],
                                   self.layers[i].derivatives(
                                                  vmodel,
-                                                 hid_scaled,
-                                                 self.weights[0].W()))
+                                                 [hid_scaled],
+                                                 [self.weights[0].W()]
+                                                 ))
+
         be.subtract_dicts_inplace(grad['layers'][i+1],
                                   self.layers[i+1].derivatives(
                                                    hid,
-                                                   vmodel_scaled,
-                                                   self.weights[0].W_T()))
+                                                   [vmodel_scaled],
+                                                   [self.weights[0].W_T()]
+                                                   ))
 
         be.subtract_dicts_inplace(grad['weights'][i],
                                   self.weights[i].derivatives(

--- a/paysage/models/hidden.py
+++ b/paysage/models/hidden.py
@@ -36,21 +36,21 @@ class State(object):
         self.units = [layers[i].random(self.shapes[i])
                       for i in range(len(layers))]
 
-    def set_visible(self, vis):
+    def set_layer(self, values, i):
         """
-        Set the visible units to vis.
+        Set the units of layer i to values.
 
         Notes:
-            Updates layer.units[0] in place.
+            Updates layer.units[i] in place.
 
         Args:
-            vis (tensor (num_samples, num_visible))
+            values (tensor (num_samples, num_units))
 
         Returns:
             None
 
         """
-        self.units[0] = vis
+        self.units[i] = values
 
     @classmethod
     def from_visible(cls, vis, layers):
@@ -67,9 +67,8 @@ class State(object):
         """
         batch_size = be.shape(vis)[0]
         state = cls(batch_size, layers)
-        state.set_visible(vis)
+        state.set_visible(vis, 0)
         return state
-
 
 
 
@@ -104,8 +103,9 @@ class Model(object):
         # the layers are stored in a list with the visible units
         # as the zeroth element
         self.layers = layer_list
+        self.len = len(self.layers)
 
-        assert len(self.layers) == 2,\
+        assert self.len == 2,\
         "Only models with 2 layers are currently supported"
 
         # adjacent layers are connected by weights

--- a/paysage/models/initialize/init_hidden.py
+++ b/paysage/models/initialize/init_hidden.py
@@ -30,12 +30,12 @@ def hinton(batch, model):
         None
 
     """
-    i = 0
-    model.weights[i].val = 0.01 * be.randn(model.weights[i].shape)
+    for i in range(len(model.weights)):
+        model.weights[i].val = 0.01 * be.randn(model.weights[i].shape)
     while True:
         try:
             v_data = batch.get(mode='train')
         except StopIteration:
             break
-        model.layers[i].online_param_update(v_data)
-    model.layers[i].shrink_parameters(shrinkage=0.01)
+        model.layers[0].online_param_update(v_data)
+    model.layers[0].shrink_parameters(shrinkage=0.01)

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -1,0 +1,60 @@
+from paysage import layers
+from paysage import constraints
+from paysage import penalties
+from paysage import backends as be
+
+
+# ----- CONSTRUCTORS ----- #
+
+def test_Layer_creation():
+    layers.Layer()
+
+def test_Weights_creation():
+    layers.Weights((8,5))
+
+def test_Gaussian_creation():
+    layers.GaussianLayer(8)
+
+def test_Ising_creation():
+    layers.IsingLayer(8)
+
+def test_Bernoulli_creation():
+    layers.BernoulliLayer(8)
+
+def test_Exponential_creation():
+    layers.ExponentialLayer(8)
+
+
+# ----- BASE METHODS ----- #
+
+def test_add_constraint():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+
+def test_enforce_constraints():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+    ly.enforce_constraints()
+
+def test_add_penalty():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+
+def test_get_penalties():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly.get_penalties()
+
+def test_parameter_step():
+    ly = layers.Weights((5,3))
+    deltas = {'matrix': be.zeros_like(ly.W())}
+    ly.parameter_step(deltas)
+
+def test_get_base_config():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly.get_base_config()

--- a/test/test_derivatives.py
+++ b/test/test_derivatives.py
@@ -38,8 +38,8 @@ def test_bernoulli_update():
     visible_field += be.broadcast(a, visible_field)
 
     # update the extrinsic parameter using the layer functions
-    rbm.layers[0].update(hdata, be.transpose(rbm.weights[0].W()))
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
+    rbm.layers[0].update([hdata], [rbm.weights[0].W_T()])
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
 
     assert be.allclose(hidden_field, rbm.layers[1].ext_params['field']), \
     "hidden field wrong in bernoulli-bernoulli rbm"
@@ -74,7 +74,7 @@ def test_bernoulli_derivatives():
     vdata_scaled = rbm.layers[0].rescale(vdata)
 
     # compute the mean of the hidden layer
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
     hid_mean = rbm.layers[1].mean()
     hid_mean_scaled = rbm.layers[1].rescale(hid_mean)
 
@@ -84,11 +84,11 @@ def test_bernoulli_derivatives():
     d_W = -be.batch_outer(vdata, hid_mean_scaled) / len(vdata)
 
     # compute the derivatives using the layer functions
-    vis_derivs = rbm.layers[0].derivatives(vdata, hid_mean_scaled,
-                                            rbm.weights[0].W())
+    vis_derivs = rbm.layers[0].derivatives(vdata, [hid_mean_scaled],
+                                            [rbm.weights[0].W()])
 
-    hid_derivs = rbm.layers[1].derivatives(hid_mean, vdata_scaled,
-                                           be.transpose(rbm.weights[0].W()))
+    hid_derivs = rbm.layers[1].derivatives(hid_mean, [vdata_scaled],
+                                          [rbm.weights[0].W_T()])
 
     weight_derivs = rbm.weights[0].derivatives(vdata, hid_mean_scaled)
 
@@ -135,8 +135,8 @@ def test_ising_update():
     visible_field += be.broadcast(a, visible_field)
 
     # update the extrinsic parameter using the layer functions
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
-    rbm.layers[0].update(hdata, be.transpose(rbm.weights[0].W()))
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
+    rbm.layers[0].update([hdata], [rbm.weights[0].W_T()])
 
     assert be.allclose(hidden_field, rbm.layers[1].ext_params['field']), \
     "hidden field wrong in ising-ising rbm"
@@ -171,7 +171,7 @@ def test_ising_derivatives():
     vdata_scaled = rbm.layers[0].rescale(vdata)
 
     # compute the mean of the hidden layer
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
     hid_mean = rbm.layers[1].mean()
     hid_mean_scaled = rbm.layers[1].rescale(hid_mean)
 
@@ -181,11 +181,13 @@ def test_ising_derivatives():
     d_W = -be.batch_outer(vdata, hid_mean_scaled) / len(vdata)
 
     # compute the derivatives using the layer functions
-    vis_derivs = rbm.layers[0].derivatives(vdata, hid_mean_scaled,
-                                            rbm.weights[0].W())
+    vis_derivs = rbm.layers[0].derivatives(vdata, [hid_mean_scaled],
+                                            [rbm.weights[0].W()]
+                                            )
 
-    hid_derivs = rbm.layers[1].derivatives(hid_mean, vdata_scaled,
-                                           be.transpose(rbm.weights[0].W()))
+    hid_derivs = rbm.layers[1].derivatives(hid_mean, [vdata_scaled],
+                                           [rbm.weights[0].W_T()]
+                                           )
 
     weight_derivs = rbm.weights[0].derivatives(vdata, hid_mean_scaled)
 
@@ -233,8 +235,8 @@ def test_exponential_update():
     visible_rate += be.broadcast(a, visible_rate)
 
     # update the extrinsic parameter using the layer functions
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
-    rbm.layers[0].update(hdata, be.transpose(rbm.weights[0].W()))
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
+    rbm.layers[0].update([hdata], [rbm.weights[0].W_T()])
 
     assert be.allclose(hidden_rate, rbm.layers[1].ext_params['rate']), \
     "hidden rate wrong in exponential-exponential rbm"
@@ -270,7 +272,7 @@ def test_exponential_derivatives():
     vdata_scaled = rbm.layers[0].rescale(vdata)
 
     # compute the mean of the hidden layer
-    rbm.layers[1].update(vdata, rbm.weights[0].W())
+    rbm.layers[1].update([vdata], [rbm.weights[0].W()])
     hid_mean = rbm.layers[1].mean()
     hid_mean_scaled = rbm.layers[1].rescale(hid_mean)
 
@@ -280,12 +282,11 @@ def test_exponential_derivatives():
     d_W = -be.batch_outer(vdata, hid_mean_scaled) / len(vdata)
 
     # compute the derivatives using the layer functions
-    vis_derivs = rbm.layers[0].derivatives(vdata, hid_mean_scaled,
-                                            rbm.weights[0].W())
+    vis_derivs = rbm.layers[0].derivatives(vdata, [hid_mean_scaled],
+                                            [rbm.weights[0].W()])
 
-    hid_derivs = rbm.layers[1].derivatives(hid_mean, vdata_scaled,
-                                           be.transpose(
-                                               rbm.weights[0].W()))
+    hid_derivs = rbm.layers[1].derivatives(hid_mean, [vdata_scaled],
+                                               [rbm.weights[0].W_T()])
 
     weight_derivs = rbm.weights[0].derivatives(vdata, hid_mean_scaled)
 
@@ -351,8 +352,8 @@ def test_gaussian_update():
     visible_mean += be.broadcast(a, visible_mean)
 
     # update the extrinsic parameters using the layer functions
-    rbm.layers[0].update(hdata_scaled, be.transpose(rbm.weights[0].W()))
-    rbm.layers[1].update(vdata_scaled, rbm.weights[0].W())
+    rbm.layers[0].update([hdata_scaled], [rbm.weights[0].W_T()])
+    rbm.layers[1].update([vdata_scaled], [rbm.weights[0].W()])
 
     assert be.allclose(visible_var, rbm.layers[0].ext_params['variance']),\
     "visible variance wrong in gaussian-gaussian rbm"
@@ -398,7 +399,7 @@ def test_gaussian_derivatives():
     vdata_scaled = vdata / be.broadcast(visible_var, vdata)
 
     # compute the mean of the hidden layer
-    rbm.layers[1].update(vdata_scaled, rbm.weights[0].W())
+    rbm.layers[1].update([vdata_scaled], [rbm.weights[0].W()])
     hidden_var = be.exp(log_var_b)
     hid_mean = rbm.layers[1].mean()
     hid_mean_scaled = rbm.layers[1].rescale(hid_mean)
@@ -420,14 +421,14 @@ def test_gaussian_derivatives():
     d_W = -be.batch_outer(vdata_scaled, hid_mean_scaled) / len(vdata_scaled)
 
     # compute the derivatives using the layer functions
-    rbm.layers[1].update(vdata_scaled, rbm.weights[0].W())
-    rbm.layers[0].update(hid_mean_scaled, be.transpose(rbm.weights[0].W()))
+    rbm.layers[1].update([vdata_scaled], [rbm.weights[0].W()])
+    rbm.layers[0].update([hid_mean_scaled], [rbm.weights[0].W_T()])
 
-    vis_derivs = rbm.layers[0].derivatives(vdata, hid_mean_scaled,
-                                            rbm.weights[0].W())
+    vis_derivs = rbm.layers[0].derivatives(vdata, [hid_mean_scaled],
+                                            [rbm.weights[0].W()])
 
-    hid_derivs = rbm.layers[1].derivatives(hid_mean, vdata_scaled,
-                                           be.transpose(rbm.weights[0].W()))
+    hid_derivs = rbm.layers[1].derivatives(hid_mean, [vdata_scaled],
+                                           [rbm.weights[0].W_T()])
 
     weight_derivs = rbm.weights[0].derivatives(vdata_scaled, hid_mean_scaled)
 


### PR DESCRIPTION
resolves #52 

Setting up some changes that are moving towards deep boltzmann machines by having the layer functions take in lists of connected layers (for instance, layer i is connected to layer i - 1 and layer i + 1 in a deep model). 

Also sets up a `State` class to keep track of the values of all of the units. Currently, derivatives are calculated by explicitly averaging over the hidden units, e.g. ` \< v E[h | v ] \>`, but this is not possible in a deep network. Instead, the hidden units must be sampled and the averages computed by like `\< v h \>` over the sampled values. We need to make this change, so that is next on the to do list.