### PR TITLE
Layers cleanup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ test:
     - pytest test/test_backends.py
     - pytest test/test_rbm.py
     - pytest test/test_derivatives.py
+    - pytest test/paysage/test_layers.py
     # pytorch currently not on pypi (only conda)
     # - pytest test/test_backends.py
 

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -43,7 +43,7 @@ class Layer(object):
         "layer_type": self.__class__.__name__,
         "intrinsic": list(self.int_params.keys()),
         "extrinsic": list(self.ext_params.keys()),
-        "penalties": {pk: self.penalties[pk].__class__.__name__
+        "penalties": {pk: self.penalties[pk].get_config()
                         for pk in self.penalties},
         "constraints": {ck: self.constraints[ck].__name__
                         for ck in self.constraints}
@@ -246,7 +246,7 @@ class Weights(Layer):
         """
         layer = cls(config["shape"])
         for k, v in config["penalties"].items():
-            layer.add_penalty({k: getattr(penalties, v)})
+            layer.add_penalty({k: penalties.from_config(v)})
         for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
@@ -382,7 +382,7 @@ class GaussianLayer(Layer):
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
         for k, v in config["penalties"].items():
-            layer.add_penalty({k: getattr(penalties, v)})
+            layer.add_penalty({k: penalties.from_config(v)})
         for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
@@ -711,7 +711,7 @@ class IsingLayer(Layer):
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
         for k, v in config["penalties"].items():
-            layer.add_penalty({k: getattr(penalties, v)})
+            layer.add_penalty({k: penalties.from_config(v)})
         for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
@@ -1004,7 +1004,7 @@ class BernoulliLayer(Layer):
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
         for k, v in config["penalties"].items():
-            layer.add_penalty({k: getattr(penalties, v)})
+            layer.add_penalty({k: penalties.from_config(v)})
         for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
@@ -1292,7 +1292,7 @@ class ExponentialLayer(Layer):
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
         for k, v in config["penalties"].items():
-            layer.add_penalty({k: getattr(penalties, v)})
+            layer.add_penalty({k: penalties.from_config(v)})
         for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -640,7 +640,7 @@ class GaussianLayer(Layer):
         Args:
             array_or_shape (array or shape tuple):
                 If tuple, then this is taken to be the shape.
-                If array, then it's shape is used.
+                If array, then its shape is used.
 
         Returns:
             tensor: Random sample with desired shape.
@@ -710,9 +710,9 @@ class IsingLayer(Layer):
         """
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
-        for k, v in config["penalties"]:
+        for k, v in config["penalties"].items():
             layer.add_penalty({k: getattr(penalties, v)})
-        for k, v in config["constraints"]:
+        for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
 
@@ -929,7 +929,7 @@ class IsingLayer(Layer):
         Args:
             array_or_shape (array or shape tuple):
                 If tuple, then this is taken to be the shape.
-                If array, then it's shape is used.
+                If array, then its shape is used.
 
         Returns:
             tensor: Random sample with desired shape.
@@ -1003,9 +1003,9 @@ class BernoulliLayer(Layer):
         """
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
-        for k, v in config["penalties"]:
+        for k, v in config["penalties"].items():
             layer.add_penalty({k: getattr(penalties, v)})
-        for k, v in config["constraints"]:
+        for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
 
@@ -1221,7 +1221,7 @@ class BernoulliLayer(Layer):
         Args:
             array_or_shape (array or shape tuple):
                 If tuple, then this is taken to be the shape.
-                If array, then it's shape is used.
+                If array, then its shape is used.
 
         Returns:
             tensor: Random sample with desired shape.
@@ -1291,9 +1291,9 @@ class ExponentialLayer(Layer):
         """
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
-        for k, v in config["penalties"]:
+        for k, v in config["penalties"].items():
             layer.add_penalty({k: getattr(penalties, v)})
-        for k, v in config["constraints"]:
+        for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
 
@@ -1508,7 +1508,7 @@ class ExponentialLayer(Layer):
         Args:
             array_or_shape (array or shape tuple):
                 If tuple, then this is taken to be the shape.
-                If array, then it's shape is used.
+                If array, then its shape is used.
 
         Returns:
             tensor: Random sample with desired shape.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -198,6 +198,10 @@ class Weights(Layer):
             They have no external parameters because they do not depend
             on the state of anything else.
 
+            The shape is regarded as a dimensionality of
+            the visible and hidden units for the layer,
+            as `shape = (visible, hidden)`.
+
         Args:
             shape (tuple): shape of the weight tensor (int, int)
 
@@ -221,7 +225,7 @@ class Weights(Layer):
             None:
 
         Returns:
-            configuratiom (dict):
+            configuration (dict):
 
         """
         base_config = self.get_base_config()
@@ -355,7 +359,7 @@ class GaussianLayer(Layer):
             None:
 
         Returns:
-            configuratiom (dict):
+            configuration (dict):
 
         """
         base_config = self.get_base_config()
@@ -377,9 +381,9 @@ class GaussianLayer(Layer):
         """
         layer = cls(config["num_units"])
         layer.sample_size = config["sample_size"]
-        for k, v in config["penalties"]:
+        for k, v in config["penalties"].items():
             layer.add_penalty({k: getattr(penalties, v)})
-        for k, v in config["constraints"]:
+        for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
 
@@ -493,7 +497,7 @@ class GaussianLayer(Layer):
         Args:
             scaled_units list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the connected units.
-            weights list[tensor, (num_connected_units, num_units)]:
+            weights list[tensor (num_connected_units, num_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.
@@ -529,7 +533,7 @@ class GaussianLayer(Layer):
                 The values of the visible units.
             hid list[tensor (num_samples, num_connected_units)]:
                 The rescaled values of the hidden units.
-            weights list[tensor, (num_units, num_connected_units)]:
+            weights list[tensor (num_units, num_connected_units)]:
                 The weights connecting the layers.
             beta (tensor (num_samples, 1), optional):
                 Inverse temperatures.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -153,7 +153,7 @@ class Layer(object):
         """
         Get the gradients of the penalties.
 
-        E.g., L2 penalty = penalty * parameter_i
+        E.g., L2 penalty gradient = penalty * parameter_i
 
         Args:
             None
@@ -241,9 +241,9 @@ class Weights(Layer):
 
         """
         layer = cls(config["shape"])
-        for k, v in config["penalties"]:
+        for k, v in config["penalties"].items():
             layer.add_penalty({k: getattr(penalties, v)})
-        for k, v in config["constraints"]:
+        for k, v in config["constraints"].items():
             layer.add_constraint({k: getattr(constraints, v)})
         return layer
 

--- a/paysage/penalties.py
+++ b/paysage/penalties.py
@@ -1,11 +1,35 @@
 from . import backends as be
 
-# ----- FUNCTIONS ----- #
+# ----- PENALTY OBJECTS ----- #
 
-class l2_penalty(object):
+class Penalty(object):
+    """
+    Base penalty class.
+    Derived classes should define `value` and `grad` functions.
 
+    """
     def __init__(self, penalty):
         self.penalty = penalty
+
+    def value(self, tensor):
+        """
+        The value of the penalty function on a tensor.
+
+        """
+        raise NotImplementedError
+
+    def grad(self, tensor):
+        """
+        The value of the gradient of the penalty function on a tensor.
+
+        """
+        raise NotImplementedError
+
+
+class l2_penalty(Penalty):
+
+    def __init__(self, penalty):
+        super().__init__(penalty)
 
     def value(self, tensor):
         return 0.5 * self.penalty * be.tsum(tensor**2)
@@ -14,10 +38,10 @@ class l2_penalty(object):
         return self.penalty * tensor
 
 
-class l1_penalty(object):
+class l1_penalty(Penalty):
 
     def __init__(self, penalty):
-        self.penalty = penalty
+        super().__init__(penalty)
 
     def value(self, tensor):
         return self.penalty * be.tsum(be.tabs(tensor))
@@ -26,10 +50,10 @@ class l1_penalty(object):
         return self.penalty * be.sign(tensor)
 
 
-class log_penalty(object):
+class log_penalty(Penalty):
 
     def __init__(self, penalty):
-        self.penalty = penalty
+        super().__init__(penalty)
 
     def value(self, tensor):
         return -self.penalty * be.log(tensor)

--- a/paysage/penalties.py
+++ b/paysage/penalties.py
@@ -1,3 +1,5 @@
+import sys
+
 from . import backends as be
 
 # ----- PENALTY OBJECTS ----- #
@@ -25,6 +27,14 @@ class Penalty(object):
         """
         raise NotImplementedError
 
+    def get_config(self):
+        """
+        Returns a config for the penalty.
+
+        """
+        return {"name": self.__class__.__name__,
+                "penalty": self.penalty
+               }
 
 class l2_penalty(Penalty):
 
@@ -60,6 +70,17 @@ class log_penalty(Penalty):
 
     def grad(self, tensor):
         return -self.penalty / tensor
+
+
+# ----- FUNCTIONS ----- #
+
+def from_config(config):
+    """
+    Builds an instance from a config.
+
+    """
+    pen = getattr(sys.modules[__name__], config["name"])
+    return pen(config["penalty"])
 
 
 # ----- ALIASES ----- #

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -3,6 +3,8 @@ from paysage import constraints
 from paysage import penalties
 from paysage import backends as be
 
+import pytest
+
 num_vis = 8
 num_hid = 5
 num_samples = 10
@@ -268,3 +270,6 @@ def test_exponential_derivatives():
     weights = [w.W()]
     beta = be.rand((num_samples, 1))
     ly.derivatives(vis, hid, weights, beta)
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -3,6 +3,9 @@ from paysage import constraints
 from paysage import penalties
 from paysage import backends as be
 
+num_vis = 8
+num_hid = 5
+num_samples = 10
 
 # ----- CONSTRUCTORS ----- #
 
@@ -10,56 +13,56 @@ def test_Layer_creation():
     layers.Layer()
 
 def test_Weights_creation():
-    layers.Weights((8,5))
+    layers.Weights((num_vis, num_hid))
 
 def test_Gaussian_creation():
-    layers.GaussianLayer(8)
+    layers.GaussianLayer(num_vis)
 
 def test_Ising_creation():
-    layers.IsingLayer(8)
+    layers.IsingLayer(num_vis)
 
 def test_Bernoulli_creation():
-    layers.BernoulliLayer(8)
+    layers.BernoulliLayer(num_vis)
 
 def test_Exponential_creation():
-    layers.ExponentialLayer(8)
+    layers.ExponentialLayer(num_vis)
 
 
 # ----- BASE METHODS ----- #
 
 def test_add_constraint():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     ly.add_constraint({'matrix': constraints.non_negative})
 
 def test_enforce_constraints():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     ly.add_constraint({'matrix': constraints.non_negative})
     ly.enforce_constraints()
 
 def test_add_penalty():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
 
 def test_get_penalties():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
     ly.get_penalties()
 
 def test_get_penalty_gradients():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
     ly.get_penalty_gradients()
 
 def test_parameter_step():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     deltas = {'matrix': be.randn(ly.shape)}
     ly.parameter_step(deltas)
 
 def test_get_base_config():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     ly.add_constraint({'matrix': constraints.non_negative})
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
@@ -69,70 +72,194 @@ def test_get_base_config():
 # ----- Weights LAYER ----- #
 
 def test_weights_build_from_config():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     ly.add_constraint({'matrix': constraints.non_negative})
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
     ly_new = layers.Layer.from_config(ly.get_config())
 
 def test_weights_derivative():
-    ly = layers.Weights((5,3))
+    ly = layers.Weights((num_vis, num_hid))
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
-    vis = be.randn((10,ly.shape[0]))
-    hid = be.randn((10,ly.shape[1]))
+    vis = be.randn((num_samples, num_vis))
+    hid = be.randn((num_samples, num_hid))
     derivs = ly.derivatives(vis, hid)
 
 def test_weights_energy():
-    ly = layers.Weights((5,3))
-    vis = be.randn((10,ly.shape[0]))
-    hid = be.randn((10,ly.shape[1]))
+    ly = layers.Weights((num_vis, num_hid))
+    vis = be.randn((num_samples, num_vis))
+    hid = be.randn((num_samples, num_hid))
     ly.energy(vis, hid)
 
 
 # ----- Gaussian LAYER ----- #
 
 def test_gaussian_build_from_config():
-    ly = layers.GaussianLayer(8)
+    ly = layers.GaussianLayer(num_vis)
     ly.add_constraint({'loc': constraints.non_negative})
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'log_var': p})
     ly_new = layers.Layer.from_config(ly.get_config())
 
 def test_gaussian_energy():
-    ly = layers.GaussianLayer(8)
-    vis = be.randn((10, ly.len))
+    ly = layers.GaussianLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
     ly.energy(vis)
 
 def test_gaussian_log_partition_function():
-    ly = layers.GaussianLayer(8)
-    vis = be.randn((10, ly.len))
+    ly = layers.GaussianLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
     ly.log_partition_function(vis)
 
 def test_gaussian_online_param_update():
-    ly = layers.GaussianLayer(8)
-    vis = be.randn((10, ly.len))
-    ly.log_partition_function(vis)
+    ly = layers.GaussianLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.online_param_update(vis)
 
 def test_gaussian_shrink_parameters():
-    ly = layers.GaussianLayer(8)
+    ly = layers.GaussianLayer(num_vis)
     ly.shrink_parameters(0.1)
 
 def test_gaussian_update():
-    ly = layers.GaussianLayer(8)
-    w = layers.Weights((5, ly.len))
-    num_samples = 10
-    scaled_units = [be.ones((num_samples, w.shape[0]))]
-    weights = [w.W()]
-    beta = be.rand((10, 1))
+    ly = layers.GaussianLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    scaled_units = [be.randn((num_samples, num_hid))]
+    weights = [w.W_T()]
+    beta = be.rand((num_samples, 1))
     ly.update(scaled_units, weights, beta)
 
 def test_gaussian_derivatives():
-    ly = layers.GaussianLayer(8)
-    w = layers.Weights((5, ly.len))
-    num_samples = 10
-    vis = be.randn((10, w.shape[1]))
-    hid = [be.randn((10, w.shape[0]))]
+    ly = layers.GaussianLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    vis = ly.random((num_samples, num_vis))
+    hid = [be.randn((num_samples, num_hid))]
+    weights = [w.W()]
+    beta = be.rand((num_samples, 1))
+    ly.derivatives(vis, hid, weights, beta)
+
+
+# ----- Ising LAYER ----- #
+
+def test_ising_build_from_config():
+    ly = layers.IsingLayer(num_vis)
+    ly.add_constraint({'loc': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'log_var': p})
+    ly_new = layers.Layer.from_config(ly.get_config())
+
+def test_ising_energy():
+    ly = layers.IsingLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.energy(vis)
+
+def test_ising_log_partition_function():
+    ly = layers.IsingLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.log_partition_function(vis)
+
+def test_ising_online_param_update():
+    ly = layers.IsingLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.online_param_update(vis)
+
+def test_ising_update():
+    ly = layers.IsingLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    scaled_units = [be.randn((num_samples, num_hid))]
     weights = [w.W_T()]
-    beta = be.rand((10, 1))
+    beta = be.rand((num_samples, 1))
+    ly.update(scaled_units, weights, beta)
+
+def test_ising_derivatives():
+    ly = layers.IsingLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    vis = ly.random((num_samples, num_vis))
+    hid = [be.randn((num_samples, num_hid))]
+    weights = [w.W()]
+    beta = be.rand((num_samples, 1))
+    ly.derivatives(vis, hid, weights, beta)
+
+
+# ----- Bernoulli LAYER ----- #
+
+def test_bernoulli_build_from_config():
+    ly = layers.BernoulliLayer(num_vis)
+    ly.add_constraint({'loc': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'log_var': p})
+    ly_new = layers.Layer.from_config(ly.get_config())
+
+def test_bernoulli_energy():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.energy(vis)
+
+def test_bernoulli_log_partition_function():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.log_partition_function(vis)
+
+def test_bernoulli_online_param_update():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.online_param_update(vis)
+
+def test_bernoulli_update():
+    ly = layers.BernoulliLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    scaled_units = [be.randn((num_samples, num_hid))]
+    weights = [w.W_T()]
+    beta = be.rand((num_samples, 1))
+    ly.update(scaled_units, weights, beta)
+
+def test_bernoulli_derivatives():
+    ly = layers.BernoulliLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    vis = ly.random((num_samples, num_vis))
+    hid = [be.randn((num_samples, num_hid))]
+    weights = [w.W()]
+    beta = be.rand((num_samples, 1))
+    ly.derivatives(vis, hid, weights, beta)
+
+
+# ----- Exponential LAYER ----- #
+
+def test_exponential_build_from_config():
+    ly = layers.BernoulliLayer(num_vis)
+    ly.add_constraint({'loc': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'log_var': p})
+    ly_new = layers.Layer.from_config(ly.get_config())
+
+def test_exponential_energy():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.energy(vis)
+
+def test_exponential_log_partition_function():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.log_partition_function(vis)
+
+def test_exponential_online_param_update():
+    ly = layers.BernoulliLayer(num_vis)
+    vis = ly.random((num_samples, num_vis))
+    ly.online_param_update(vis)
+
+def test_exponential_update():
+    ly = layers.BernoulliLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    scaled_units = [be.randn((num_samples, num_hid))]
+    weights = [w.W_T()]
+    beta = be.rand((num_samples, 1))
+    ly.update(scaled_units, weights, beta)
+
+def test_exponential_derivatives():
+    ly = layers.BernoulliLayer(num_vis)
+    w = layers.Weights((num_vis, num_hid))
+    vis = ly.random((num_samples, num_vis))
+    hid = [be.randn((num_samples, num_hid))]
+    weights = [w.W()]
+    beta = be.rand((num_samples, 1))
     ly.derivatives(vis, hid, weights, beta)

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -77,6 +77,7 @@ def test_weights_build_from_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
     ly_new = layers.Layer.from_config(ly.get_config())
+    assert ly_new.get_config() == ly.get_config()
 
 def test_weights_derivative():
     ly = layers.Weights((num_vis, num_hid))
@@ -101,6 +102,7 @@ def test_gaussian_build_from_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'log_var': p})
     ly_new = layers.Layer.from_config(ly.get_config())
+    assert ly_new.get_config() == ly.get_config()
 
 def test_gaussian_energy():
     ly = layers.GaussianLayer(num_vis)
@@ -147,6 +149,7 @@ def test_ising_build_from_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'log_var': p})
     ly_new = layers.Layer.from_config(ly.get_config())
+    assert ly_new.get_config() == ly.get_config()
 
 def test_ising_energy():
     ly = layers.IsingLayer(num_vis)
@@ -189,6 +192,7 @@ def test_bernoulli_build_from_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'log_var': p})
     ly_new = layers.Layer.from_config(ly.get_config())
+    assert ly_new.get_config() == ly.get_config()
 
 def test_bernoulli_energy():
     ly = layers.BernoulliLayer(num_vis)
@@ -231,6 +235,7 @@ def test_exponential_build_from_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'log_var': p})
     ly_new = layers.Layer.from_config(ly.get_config())
+    assert ly_new.get_config() == ly.get_config()
 
 def test_exponential_energy():
     ly = layers.BernoulliLayer(num_vis)

--- a/test/paysage/test_layers.py
+++ b/test/paysage/test_layers.py
@@ -47,6 +47,12 @@ def test_get_penalties():
     ly.add_penalty({'matrix': p})
     ly.get_penalties()
 
+def test_get_penalty_gradients():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly.get_penalty_gradients()
+
 def test_parameter_step():
     ly = layers.Weights((5,3))
     deltas = {'matrix': be.zeros_like(ly.W())}
@@ -58,3 +64,30 @@ def test_get_base_config():
     p = penalties.l2_penalty(0.37)
     ly.add_penalty({'matrix': p})
     ly.get_base_config()
+
+
+# ----- Weights LAYER ----- #
+
+def test_weights_derivative():
+    ly = layers.Weights((5,3))
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    vis = be.ones((10,ly.shape[0]))
+    hid = be.ones((10,ly.shape[1]))
+    derivs = ly.derivatives(vis, hid)
+
+def test_weights_energy():
+    ly = layers.Weights((5,3))
+    vis = be.ones((10,ly.shape[0]))
+    hid = be.ones((10,ly.shape[1]))
+    ly.energy(vis, hid)
+
+def test_build_from_config():
+    ly = layers.Weights((5,3))
+    ly.add_constraint({'matrix': constraints.non_negative})
+    p = penalties.l2_penalty(0.37)
+    ly.add_penalty({'matrix': p})
+    ly_new = layers.Weights.from_config(ly.get_config())
+
+
+# ----- Gaussian LAYER ----- #


### PR DESCRIPTION
Adds more extensive tests for layer methods.  The tests over the Gaussian, Ising, Bernoulli, and Exponential layers could be pulled out into a pytest fixture, but leaving them explicit for now since we will probably want to make more detailed tests than what is currently there (checking that the nontrivial methods can be called).

Also some docs cleanup, and converts the penalties into derived classes from a base.