### PR TITLE
Add profiling scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ __pycache__
 # Conda files
 .spyderproject
 
+# Profiling files
+*.cprof

--- a/circle.yml
+++ b/circle.yml
@@ -33,11 +33,12 @@ test:
     - pytest test/test_derivatives.py
     - pytest test/paysage/test_layers.py
     - echo "No profiling run" > ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof
+    - python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py
     # Test docker container
     # - docker run paysage
 
   post:
-    # Run profiling as nightly build (takes too long to include in regular CI)
+    # Run profiling as nightly build
     - >
       if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
         python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py

--- a/circle.yml
+++ b/circle.yml
@@ -32,13 +32,13 @@ test:
     - pytest test/test_rbm.py
     - pytest test/test_derivatives.py
     - pytest test/paysage/test_layers.py
-    - echo "No profiling run" > ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof
-    - python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py
     # Test docker container
     # - docker run paysage
 
   post:
-    # Run profiling as nightly build
+    # Profiling
+    - echo "No profiling run" > ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof
+    # - python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py
     - >
       if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
         python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 
 general:
   artifacts:
-    ./paysage_profiling.cprof
+    "paysage_profiling.cprof"
 
 dependencies:
   pre:
@@ -18,12 +18,12 @@ dependencies:
     # CI image includes only 3.4 shared library
     - sudo ln -s /usr/lib/x86_64-linux-gnu/libpython3.4m.so.1.0 /usr/lib/x86_64-linux-gnu/libpython3.6m.so.1.0
     - pip install -U -r requirements.txt
-
   post:
-    # - docker build --rm=false -t paysage .
     - pip install http://download.pytorch.org/whl/cu75/torch-0.1.10.post2-cp36-cp36m-linux_x86_64.whl
     - pip install torchvision
     - pip install -e .
+    # Build docker container
+    # - docker build --rm=false -t paysage .
 
 test:
   pre:
@@ -36,9 +36,13 @@ test:
     - pytest test/test_rbm.py
     - pytest test/test_derivatives.py
     - pytest test/paysage/test_layers.py
-
-    # profiling
-    - python -m cProfile -o paysage_profiling.cprof examples/profile_paysage.py
-
-    # check docker container functionality
+    - echo "No profiling run" > paysage_profiling.cprof
+    # Test docker container
     # - docker run paysage
+
+  post:
+    # Run profiling as nightly build (takes too long to include in regular CI
+    - >
+      if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
+        python -m cProfile -o paysage_profiling.cprof examples/profile_paysage.py
+      fi   

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
   services:
     - docker
 
+general:
+  artifacts:
+    ./paysage_profiling.cprof
 
 dependencies:
   pre:
@@ -33,12 +36,9 @@ test:
     - pytest test/test_rbm.py
     - pytest test/test_derivatives.py
     - pytest test/paysage/test_layers.py
-    # pytorch currently not on pypi (only conda)
-    # - pytest test/test_backends.py
+
+    # profiling
+    - python -m cProfile -o paysage_profiling.cprof ./profile_paysage.py
 
     # check docker container functionality
     # - docker run paysage
-
-    # check that examples run to completion (exclude this for now due to long CI runtimes)
-    # - python3 examples/example_mnist_grbm.py
-    # ...

--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,6 @@ machine:
   services:
     - docker
 
-general:
-  artifacts:
-    "paysage_profiling.cprof"
-
 dependencies:
   pre:
     - sudo apt-get install libhdf5-dev
@@ -36,13 +32,13 @@ test:
     - pytest test/test_rbm.py
     - pytest test/test_derivatives.py
     - pytest test/paysage/test_layers.py
-    - echo "No profiling run" > paysage_profiling.cprof
+    - echo "No profiling run" > ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof
     # Test docker container
     # - docker run paysage
 
   post:
-    # Run profiling as nightly build (takes too long to include in regular CI
+    # Run profiling as nightly build (takes too long to include in regular CI)
     - >
       if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
-        python -m cProfile -o paysage_profiling.cprof examples/profile_paysage.py
+        python -m cProfile -o ${CIRCLE_ARTIFACTS}/paysage_profiling.cprof examples/profile_paysage.py
       fi   

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ test:
     - pytest test/paysage/test_layers.py
 
     # profiling
-    - python -m cProfile -o paysage_profiling.cprof ./examples/profile_paysage.py
+    - python -m cProfile -o paysage_profiling.cprof examples/profile_paysage.py
 
     # check docker container functionality
     # - docker run paysage

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ test:
     - pytest test/paysage/test_layers.py
 
     # profiling
-    - python -m cProfile -o paysage_profiling.cprof ./profile_paysage.py
+    - python -m cProfile -o paysage_profiling.cprof ./examples/profile_paysage.py
 
     # check docker container functionality
     # - docker run paysage

--- a/examples/all_examples.py
+++ b/examples/all_examples.py
@@ -3,13 +3,13 @@ import example_mnist_hopfield as hopfield
 import example_mnist_rbm as rbm
 
 def all_examples():
-    print("grbm")
+    print("GRBM")
     grbm.example_mnist_grbm()
-    print("hopfield")
+    print("Hopfield")
     hopfield.example_mnist_hopfield()
-    print("rbm")
+    print("RBM")
     rbm.example_mnist_rbm()
-    print("Finished all examples")
+    print("Finished")
 
 if __name__ == "__main__":
     all_examples()

--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -14,11 +14,10 @@ import example_util as util
 
 transform = partial(batch.scale, denominator=255)
 
-def example_mnist_grbm(paysage_path = None, show_plot = False):
+def example_mnist_grbm(paysage_path = None, num_epochs = 10, show_plot = False):
 
     num_hidden_units = 500
     batch_size = 50
-    num_epochs = 10
     learning_rate = 0.001 # gaussian rbm usually requires smaller learnign rate
     mc_steps = 1
 
@@ -60,7 +59,6 @@ def example_mnist_grbm(paysage_path = None, show_plot = False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = [M.ReconstructionError(), M.EnergyDistance(), M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 

--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -6,6 +6,7 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
+from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
@@ -46,17 +47,12 @@ def example_mnist_grbm(paysage_path = None, show_plot = False):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm,
-                 data,
-                 opt,
-                 sampler,
-                 num_epochs,
-                 mcsteps=mc_steps,
-                 skip=200,
-                 metrics=['ReconstructionError',
-                          'EnergyDistance',
-                          'EnergyGap',
-                          'EnergyZscore'])
+    cd = fit.PCD(rbm, data, opt, sampler,
+                 num_epochs, mcsteps=mc_steps, skip=200,
+                 metrics=[M.ReconstructionError(),
+                          M.EnergyDistance(),
+                          M.EnergyGap(),
+                          M.EnergyZscore()])
 
     # fit the model
     print('training with contrastive divergence')
@@ -65,7 +61,7 @@ def example_mnist_grbm(paysage_path = None, show_plot = False):
     # evaluate the model
     # this will be the same as the final epoch results
     # it is repeated here to be consistent with the sklearn rbm example
-    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
+    metrics = [M.ReconstructionError(), M.EnergyDistance(), M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -45,8 +45,7 @@ def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm, data, opt, sampler,
-                 num_epochs, mcsteps=mc_steps, skip=200,
+    cd = fit.PCD(rbm, data, opt, sampler, num_epochs, mcsteps=mc_steps, skip=200,
                  metrics=['ReconstructionError',
                           'EnergyDistance',
                           'EnergyGap',
@@ -58,7 +57,6 @@ def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 

--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -6,7 +6,6 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
-from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
@@ -14,7 +13,7 @@ import example_util as util
 
 transform = partial(batch.scale, denominator=255)
 
-def example_mnist_grbm(paysage_path = None, num_epochs = 10, show_plot = False):
+def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
 
     num_hidden_units = 500
     batch_size = 50
@@ -48,10 +47,10 @@ def example_mnist_grbm(paysage_path = None, num_epochs = 10, show_plot = False):
 
     cd = fit.PCD(rbm, data, opt, sampler,
                  num_epochs, mcsteps=mc_steps, skip=200,
-                 metrics=[M.ReconstructionError(),
-                          M.EnergyDistance(),
-                          M.EnergyGap(),
-                          M.EnergyZscore()])
+                 metrics=['ReconstructionError',
+                          'EnergyDistance',
+                          'EnergyGap',
+                          'EnergyZscore'])
 
     # fit the model
     print('training with contrastive divergence')
@@ -59,7 +58,8 @@ def example_mnist_grbm(paysage_path = None, num_epochs = 10, show_plot = False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    metrics = [M.ReconstructionError(), M.EnergyDistance(), M.EnergyGap(), M.EnergyZscore()]
+    # it is repeated here to be consistent with the sklearn rbm example
+    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_mnist_hopfield.py
+++ b/examples/example_mnist_hopfield.py
@@ -10,11 +10,10 @@ be.set_seed(137) # for determinism
 
 import example_util as util
 
-def example_mnist_hopfield(paysage_path = None, show_plot = False):
+def example_mnist_hopfield(paysage_path = None, num_epochs = 10, show_plot = False):
 
     num_hidden_units = 500
     batch_size = 50
-    num_epochs = 10
     learning_rate = 0.001
     mc_steps = 1
 
@@ -56,7 +55,6 @@ def example_mnist_hopfield(paysage_path = None, show_plot = False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = [M.ReconstructionError(), M.EnergyDistance(),
                M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)

--- a/examples/example_mnist_hopfield.py
+++ b/examples/example_mnist_hopfield.py
@@ -4,6 +4,7 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
+from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
@@ -42,17 +43,12 @@ def example_mnist_hopfield(paysage_path = None, show_plot = False):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm,
-                 data,
-                 opt,
-                 sampler,
-                 num_epochs,
-                 mcsteps=mc_steps,
-                 skip=200,
-                 metrics=['ReconstructionError',
-                          'EnergyDistance',
-                          'EnergyGap',
-                          'EnergyZscore'])
+    cd = fit.PCD(rbm, data, opt, sampler,
+                 num_epochs, mcsteps=mc_steps, skip=200,
+                 metrics=[M.ReconstructionError(),
+                          M.EnergyDistance(),
+                          M.EnergyGap(),
+                          M.EnergyZscore()])
 
     # fit the model
     print('training with contrastive divergence')
@@ -61,7 +57,8 @@ def example_mnist_hopfield(paysage_path = None, show_plot = False):
     # evaluate the model
     # this will be the same as the final epoch results
     # it is repeated here to be consistent with the sklearn rbm example
-    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
+    metrics = [M.ReconstructionError(), M.EnergyDistance(),
+               M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_mnist_hopfield.py
+++ b/examples/example_mnist_hopfield.py
@@ -41,13 +41,7 @@ def example_mnist_hopfield(paysage_path=None, num_epochs=10, show_plot=False):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm,
-                 data,
-                 opt,
-                 sampler,
-                 num_epochs,
-                 mcsteps=mc_steps,
-                 skip=200,
+    cd = fit.PCD(rbm, data, opt, sampler, num_epochs, mcsteps=mc_steps, skip=200,
                  metrics=['ReconstructionError',
                           'EnergyDistance',
                           'EnergyGap',
@@ -59,7 +53,6 @@ def example_mnist_hopfield(paysage_path=None, num_epochs=10, show_plot=False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 

--- a/examples/example_mnist_hopfield.py
+++ b/examples/example_mnist_hopfield.py
@@ -4,13 +4,12 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
-from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
 import example_util as util
 
-def example_mnist_hopfield(paysage_path = None, num_epochs = 10, show_plot = False):
+def example_mnist_hopfield(paysage_path=None, num_epochs=10, show_plot=False):
 
     num_hidden_units = 500
     batch_size = 50
@@ -42,12 +41,17 @@ def example_mnist_hopfield(paysage_path = None, num_epochs = 10, show_plot = Fal
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm, data, opt, sampler,
-                 num_epochs, mcsteps=mc_steps, skip=200,
-                 metrics=[M.ReconstructionError(),
-                          M.EnergyDistance(),
-                          M.EnergyGap(),
-                          M.EnergyZscore()])
+    cd = fit.PCD(rbm,
+                 data,
+                 opt,
+                 sampler,
+                 num_epochs,
+                 mcsteps=mc_steps,
+                 skip=200,
+                 metrics=['ReconstructionError',
+                          'EnergyDistance',
+                          'EnergyGap',
+                          'EnergyZscore'])
 
     # fit the model
     print('training with contrastive divergence')
@@ -55,8 +59,8 @@ def example_mnist_hopfield(paysage_path = None, num_epochs = 10, show_plot = Fal
 
     # evaluate the model
     # this will be the same as the final epoch results
-    metrics = [M.ReconstructionError(), M.EnergyDistance(),
-               M.EnergyGap(), M.EnergyZscore()]
+    # it is repeated here to be consistent with the sklearn rbm example
+    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -4,6 +4,7 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
+from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
@@ -41,17 +42,12 @@ def example_mnist_rbm(paysage_path=None, show_plot = False):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm,
-                 data,
-                 opt,
-                 sampler,
-                 num_epochs,
-                 mcsteps=mc_steps,
-                 skip=200,
-                 metrics=['ReconstructionError',
-                          'EnergyDistance',
-                          'EnergyGap',
-                          'EnergyZscore'])
+    cd = fit.PCD(rbm, data, opt, sampler,
+                 num_epochs, mcsteps=mc_steps, skip=200,
+                 metrics=[M.ReconstructionError(),
+                          M.EnergyDistance(),
+                          M.EnergyGap(),
+                          M.EnergyZscore()])
 
     # fit the model
     print('training with contrastive divergence')
@@ -60,7 +56,8 @@ def example_mnist_rbm(paysage_path=None, show_plot = False):
     # evaluate the model
     # this will be the same as the final epoch results
     # it is repeated here to be consistent with the sklearn rbm example
-    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
+    metrics = [M.ReconstructionError(), M.EnergyDistance(),
+               M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -53,7 +53,6 @@ def example_mnist_rbm(paysage_path=None, num_epochs=10, show_plot=False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -10,10 +10,9 @@ be.set_seed(137) # for determinism
 
 import example_util as util
 
-def example_mnist_rbm(paysage_path=None, show_plot = False):
+def example_mnist_rbm(paysage_path=None, num_epochs = 10, show_plot = False):
     num_hidden_units = 500
     batch_size = 50
-    num_epochs = 10
     learning_rate = 0.01
     mc_steps = 1
 
@@ -55,7 +54,6 @@ def example_mnist_rbm(paysage_path=None, show_plot = False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    # it is repeated here to be consistent with the sklearn rbm example
     metrics = [M.ReconstructionError(), M.EnergyDistance(),
                M.EnergyGap(), M.EnergyZscore()]
     performance = fit.ProgressMonitor(0, data, metrics=metrics)

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -4,13 +4,12 @@ from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
 from paysage import backends as be
-from paysage import metrics as M
 
 be.set_seed(137) # for determinism
 
 import example_util as util
 
-def example_mnist_rbm(paysage_path=None, num_epochs = 10, show_plot = False):
+def example_mnist_rbm(paysage_path=None, num_epochs=10, show_plot=False):
     num_hidden_units = 500
     batch_size = 50
     learning_rate = 0.01
@@ -43,10 +42,10 @@ def example_mnist_rbm(paysage_path=None, num_epochs = 10, show_plot = False):
 
     cd = fit.PCD(rbm, data, opt, sampler,
                  num_epochs, mcsteps=mc_steps, skip=200,
-                 metrics=[M.ReconstructionError(),
-                          M.EnergyDistance(),
-                          M.EnergyGap(),
-                          M.EnergyZscore()])
+                 metrics=['ReconstructionError',
+                          'EnergyDistance',
+                          'EnergyGap',
+                          'EnergyZscore'])
 
     # fit the model
     print('training with contrastive divergence')
@@ -54,8 +53,8 @@ def example_mnist_rbm(paysage_path=None, num_epochs = 10, show_plot = False):
 
     # evaluate the model
     # this will be the same as the final epoch results
-    metrics = [M.ReconstructionError(), M.EnergyDistance(),
-               M.EnergyGap(), M.EnergyZscore()]
+    # it is repeated here to be consistent with the sklearn rbm example
+    metrics = ['ReconstructionError', 'EnergyDistance', 'EnergyGap', 'EnergyZscore']
     performance = fit.ProgressMonitor(0, data, metrics=metrics)
 
     util.show_metrics(rbm, performance)

--- a/examples/example_util.py
+++ b/examples/example_util.py
@@ -1,5 +1,4 @@
 import os
-
 import numpy
 
 import plotting
@@ -81,10 +80,10 @@ def show_fantasy_particles(rbm, v_data, fit, show_plot):
     example_plot(grid, show_plot)
 
 def compute_weights(rbm):
-    idx = numpy.random.choice(
-          range(rbm.weights[0].shape[1]),
-          5, replace=False)
-    return numpy.array([[be.to_numpy_array(rbm.weights[0].W()[:, i])] for i in idx])
+    idx = numpy.random.choice(range(rbm.weights[0].shape[1]),
+                              5, replace=False)
+    return numpy.array([[be.to_numpy_array(rbm.weights[0].W()[:, i])]
+                        for i in idx])
 
 def show_weights(rbm, show_plot):
     print("\nPlot a random sample of the weights")

--- a/examples/profile_paysage.py
+++ b/examples/profile_paysage.py
@@ -1,0 +1,28 @@
+import cProfile
+import pstats
+
+import example_mnist_grbm as grbm
+import example_mnist_hopfield as hopfield
+import example_mnist_rbm as rbm
+
+def run_profiling() -> None:
+    """
+    Execute a shortened run of example models
+    """
+    # grbm.example_mnist_grbm(num_epochs=1)
+    # hopfield.example_mnist_hopfield(num_epochs=1)
+    rbm.example_mnist_rbm(num_epochs=2)
+
+def pstats() -> None:
+    """
+    Example showing some pstats analysis of the run
+    """
+    cProfile.run("run_profiling()", 'profstats')
+    p = pstats.Stats('profstats')
+    p.sort_stats('cumulative').print_stats(20)
+    p.sort_stats('time').print_stats(20)
+    p.sort_stats('cumulative').print_callers(5)
+    p.sort_stats('time').print_callers(5)
+
+if __name__ == "__main__":
+    run_profiling()

--- a/examples/profile_paysage.py
+++ b/examples/profile_paysage.py
@@ -5,13 +5,17 @@ import example_mnist_grbm as grbm
 import example_mnist_hopfield as hopfield
 import example_mnist_rbm as rbm
 
-def run_profiling() -> None:
+
+def run_profiling(mode="short") -> None:
     """
     Execute a shortened run of example models
     """
-    # grbm.example_mnist_grbm(num_epochs=1)
-    # hopfield.example_mnist_hopfield(num_epochs=1)
-    rbm.example_mnist_rbm(num_epochs=2)
+    if mode == "short":
+        rbm.example_mnist_rbm(num_epochs=3)
+    else:
+        grbm.example_mnist_grbm()
+        hopfield.example_mnist_hopfield()
+        rbm.example_mnist_rbm()
 
 def pstats() -> None:
     """
@@ -21,8 +25,6 @@ def pstats() -> None:
     p = pstats.Stats('profstats')
     p.sort_stats('cumulative').print_stats(20)
     p.sort_stats('time').print_stats(20)
-    p.sort_stats('cumulative').print_callers(5)
-    p.sort_stats('time').print_callers(5)
 
 if __name__ == "__main__":
-    run_profiling()
+    run_profiling("short")

--- a/examples/profile_paysage.sh
+++ b/examples/profile_paysage.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run profiling, output to paysage.cprof
+
+set -eu
+
+echo "Running paysage profiling"
+echo "========================="
+
+timestamp=$(date +"%Y%m%d_%H%M%S")
+
+pip3 install snakeviz
+python3 -m cProfile -o paysage_${timestamp}.cprof ./profile_paysage.py
+snakeviz paysage_${timestamp}.cprof

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -137,7 +137,7 @@ class TrainingMethod(object):
 
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  skip=100,
-                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
+                 metrics=['ReconstructionError', 'EnergyDistance']):
         self.model = model
         self.batch = abatch
         self.epochs = epochs
@@ -164,7 +164,7 @@ class ContrastiveDivergence(TrainingMethod):
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  mcsteps=1,
                  skip=100,
-                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
+                 metrics=['ReconstructionError', 'EnergyDistance']):
         super().__init__(model, abatch, optimizer, sampler, epochs,
                         skip=skip,
                         metrics=metrics)
@@ -228,7 +228,7 @@ class PersistentContrastiveDivergence(TrainingMethod):
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  mcsteps=1,
                  skip=100,
-                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
+                 metrics=['ReconstructionError', 'EnergyDistance']):
        super().__init__(model, abatch, optimizer, sampler, epochs,
                         skip=skip,
                         metrics=metrics)
@@ -280,11 +280,11 @@ class PersistentContrastiveDivergence(TrainingMethod):
 class ProgressMonitor(object):
 
     def __init__(self, skip, batch,
-                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
+                 metrics=['ReconstructionError', 'EnergyDistance']):
         self.skip = skip
         self.batch = batch
         self.update_steps = 10
-        self.metrics = metrics
+        self.metrics = [M.__getattribute__(m)() for m in metrics]
         self.memory = []
 
     def check_progress(self, model, t,

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -121,7 +121,7 @@ class TrainingMethod(object):
 
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  skip=100,
-                 metrics=['ReconstructionError', 'EnergyDistance']):
+                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
         self.model = model
         self.batch = abatch
         self.epochs = epochs
@@ -147,7 +147,7 @@ class ContrastiveDivergence(TrainingMethod):
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  mcsteps=1,
                  skip=100,
-                 metrics=['ReconstructionError', 'EnergyDistance']):
+                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
         super().__init__(model, abatch, optimizer, sampler, epochs,
                         skip=skip,
                         metrics=metrics)
@@ -205,7 +205,7 @@ class PersistentContrastiveDivergence(TrainingMethod):
     def __init__(self, model, abatch, optimizer, sampler, epochs,
                  mcsteps=1,
                  skip=100,
-                 metrics=['ReconstructionError', 'EnergyDistance']):
+                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
        super().__init__(model, abatch, optimizer, sampler, epochs,
                         skip=skip,
                         metrics=metrics)
@@ -250,11 +250,11 @@ class PersistentContrastiveDivergence(TrainingMethod):
 class ProgressMonitor(object):
 
     def __init__(self, skip, batch,
-                 metrics=['ReconstructionError', 'EnergyDistance']):
+                 metrics=[M.ReconstructionError(), M.EnergyDistance()]):
         self.skip = skip
         self.batch = batch
         self.update_steps = 10
-        self.metrics = [M.__getattribute__(m)() for m in metrics]
+        self.metrics = metrics
         self.memory = []
 
     def check_progress(self, model, t,
@@ -286,11 +286,11 @@ class ProgressMonitor(object):
 
                 # compile argdict
                 argdict = {
-                'minibatch': v_data,
-                'reconstructions': reconstructions,
-                'random_samples': random_samples,
-                'samples': fantasy_particles,
-                'amodel': model
+                    'minibatch': v_data,
+                    'reconstructions': reconstructions,
+                    'random_samples': random_samples,
+                    'samples': fantasy_particles,
+                    'amodel': model
                 }
 
                 # update metrics

--- a/test/test_rbm.py
+++ b/test/test_rbm.py
@@ -6,7 +6,6 @@ from paysage import layers
 from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
-from paysage import metrics as M
 
 import pytest
 
@@ -56,7 +55,7 @@ def test_rbm(paysage_path=None):
     perf  = fit.ProgressMonitor(0,
                                 data,
                                 metrics=[
-                                M.ReconstructionError()])
+                                'ReconstructionError'])
     untrained_performance = perf.check_progress(rbm, 0)
 
 
@@ -73,7 +72,7 @@ def test_rbm(paysage_path=None):
                  num_epochs,
                  mcsteps=mc_steps,
                  skip=200,
-                 metrics=[M.ReconstructionError()])
+                 metrics=['ReconstructionError'])
 
 
     # fit the model

--- a/test/test_rbm.py
+++ b/test/test_rbm.py
@@ -10,7 +10,8 @@ from paysage import optimizers
 import pytest
 
 def test_rbm(paysage_path=None):
-    """TODO : this is just a placeholder, need to clean up & simplifiy setup. Also
+    """
+    TODO : this is just a placeholder, need to clean up & simplifiy setup. Also
     need to figure how to deal with consistent random seeding throughout the
     codebase to obtain deterministic checkable results.
     """
@@ -68,12 +69,8 @@ def test_rbm(paysage_path=None):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm, data, opt, sampler,
-                 num_epochs,
-                 mcsteps=mc_steps,
-                 skip=200,
-                 metrics=['ReconstructionError'])
-
+    cd = fit.PCD(rbm, data, opt, sampler, num_epochs, mcsteps=mc_steps,
+                 skip=200, metrics=['ReconstructionError'])
 
     # fit the model
     print('training with contrastive divergence')

--- a/test/test_rbm.py
+++ b/test/test_rbm.py
@@ -6,6 +6,7 @@ from paysage import layers
 from paysage.models import hidden
 from paysage import fit
 from paysage import optimizers
+from paysage import metrics as M
 
 import pytest
 
@@ -55,7 +56,7 @@ def test_rbm(paysage_path=None):
     perf  = fit.ProgressMonitor(0,
                                 data,
                                 metrics=[
-                                'ReconstructionError'])
+                                M.ReconstructionError()])
     untrained_performance = perf.check_progress(rbm, 0)
 
 
@@ -68,14 +69,11 @@ def test_rbm(paysage_path=None):
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
                                                 method='stochastic')
 
-    cd = fit.PCD(rbm,
-                 data,
-                 opt,
-                 sampler,
+    cd = fit.PCD(rbm, data, opt, sampler,
                  num_epochs,
                  mcsteps=mc_steps,
                  skip=200,
-                 metrics=['ReconstructionError'])
+                 metrics=[M.ReconstructionError()])
 
 
     # fit the model


### PR DESCRIPTION
`profile_paysage.sh` in `examples/` runs profiling with cProfile and shows results using snakeviz.

Modified examples code to parameterize # of epochs allowing for shorter runs. Reverted some changes on the fork to expose metric classes instead of using strings (in this PR I keep the upstream strings representation).

Started adding profiling to CI but need to either offload profiling runs on a separate server or set it up as a nightly build since o/w CI is too slow.