### PR TITLE
Add 'persistent' training option to TAP machines

### DIFF
--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -9,7 +9,7 @@ be.set_seed(137) # for determinism
 
 import example_util as util
 
-def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True):
+def example_mnist_tap_machine(paysage_path=None, num_epochs = 30, show_plot=True):
 
     num_hidden_units = 500
     batch_size = 100
@@ -30,7 +30,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
     rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=0,
-                              tolerance_EMF=1e-1, max_iters_EMF=100)
+                              tolerance_EMF=1e-2, max_iters_EMF=100)
     rbm.initialize(data, 'hinton')
 
     # set up the optimizer and the fit method
@@ -69,4 +69,4 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     print("Done")
 
 if __name__ == "__main__":
-    example_mnist_tap_machine(show_plot = False)
+    example_mnist_tap_machine(show_plot = True)

--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -29,7 +29,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     vis_layer = layers.BernoulliLayer(data.ncols)
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
-    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer],
+    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], persistent=False,
                               tolerance_EMF=1e-1, max_iters_EMF=100)
     rbm.initialize(data, 'hinton')
 

--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -29,7 +29,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     vis_layer = layers.BernoulliLayer(data.ncols)
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
-    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], persistent=False,
+    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=0,
                               tolerance_EMF=1e-1, max_iters_EMF=100)
     rbm.initialize(data, 'hinton')
 


### PR DESCRIPTION
We add the ability to use any number of persistent points as seeds for the Gibbs free energy estimation that occurs every time we operate on a minibatch.  Although the papers on TAP rbms suggest that this is a fruitful idea for training, so far this is not performing better than random initialization but could prove powerful if coupled with different minimization methods.  By default, and in the demo example, the initialization scheme is set to use random initialization.

