### PR TITLE
Norm axis

### DIFF
--- a/paysage/backends/python_backend/matrix.py
+++ b/paysage/backends/python_backend/matrix.py
@@ -383,19 +383,32 @@ def normalize(x: T.Tensor) -> T.Tensor:
     y = EPSILON + x
     return x/numpy.sum(y)
 
-def norm(x: T.Tensor) -> float:
+def norm(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
     Return the L2 norm of a tensor.
 
     Args:
         x: A tensor.
+        axis (optional): the axis for taking the norm
+        keepdims (optional): If this is set to true, the dimension of the tensor
+                             is unchanged. Otherwise, the reduced axis is removed
+                             and the dimension of the array is 1 less.
 
     Returns:
-        float: The L2 norm of the tensor
+        if axis is none:
+            float: The L2 norm of the tensor
                (i.e., the sqrt of the sum of the squared elements).
+        else:
+            tensor: The L2 norm along the specified axis.
 
     """
-    return numpy.linalg.norm(x)
+    if axis is None:
+        return numpy.linalg.norm(x)
+    else:
+        if keepdims:
+            return numpy.expand_dims(numpy.linalg.norm(x, axis=axis), axis)
+        else:
+            return numpy.linalg.norm(x, axis=axis)
 
 def tmax(x: T.Tensor, axis: int=None, keepdims: bool=False)-> T.FloatingPoint:
     """

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -397,19 +397,32 @@ def normalize(x: T.FloatTensor) -> T.FloatTensor:
     """
     return x.div(torch.sum(EPSILON + x))
 
-def norm(x: T.FloatTensor) -> float:
+def norm(x: T.FloatTensor,  axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
     Return the L2 norm of a tensor.
 
     Args:
         x: A tensor.
+        axis (optional): the axis for taking the norm
+        keepdims (optional): If this is set to true, the dimension of the tensor
+                             is unchanged. Otherwise, the reduced axis is removed
+                             and the dimension of the array is 1 less.
 
     Returns:
-        float: The L2 norm of the tensor
+        if axis is none:
+            float: The L2 norm of the tensor
                (i.e., the sqrt of the sum of the squared elements).
+        else:
+            tensor: The L2 norm along the specified axis.
 
     """
-    return x.norm()
+    if axis is None:
+        return x.norm()
+    else:
+        if keepdims:
+            return x.norm(2, axis)
+        else:
+            return flatten(x.norm(2, axis))
 
 def tmax(x: T.FloatTensor,
          axis: int = None,

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -312,17 +312,28 @@ def test_normalize():
     assert_close(py_norm, torch_norm, "normalize")
 
 def test_norm():
-    shape = (100,)
+    shape = (100, 100)
 
     py_rand.set_seed()
     py_x = py_rand.rand(shape)
     torch_x = torch_matrix.float_tensor(py_x)
 
+    # overall norm
     py_norm = py_matrix.norm(py_x)
     torch_norm = torch_matrix.norm(torch_x)
 
     assert allclose(py_norm, torch_norm), \
     "python l2 norm != torch l2 norm"
+
+    # norm over axis 0, keepdims = False
+    py_norm = py_matrix.norm(py_x, axis=0)
+    torch_norm = torch_matrix.norm(torch_x, axis=0)
+    assert_close(py_norm, torch_norm, "norm (axis-0)")
+
+    # norm over axis 0, keepdims
+    py_norm = py_matrix.norm(py_x, axis=0, keepdims=True)
+    torch_norm = torch_matrix.norm(torch_x, axis=0, keepdims=True)
+    assert_close(py_norm, torch_norm, "norm (axis-0, keepdims)")
 
 def test_tmax():
     shape = (100, 100)


### PR DESCRIPTION
Add `axis` and `keepdims` kwargs to the backend `norm` functions, along with tests.