### PR TITLE
Tap3

### DIFF
--- a/docs/gradient_util.md
+++ b/docs/gradient_util.md
@@ -93,7 +93,7 @@ Apply an in place function entrywise over the zip of two Gradient objects.<br />
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, verbose=False, rename=False)
+def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
 
 ```
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1398,7 +1398,7 @@ def get(key)
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, verbose=False, rename=False)
+def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
 
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -221,7 +221,7 @@ Get the value of the energy gap.<br /><br />Args:<br /> ~ None<br /><br />Return
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, verbose=False, rename=False)
+def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
 
 ```
 

--- a/docs/tap_machine.md
+++ b/docs/tap_machine.md
@@ -20,13 +20,13 @@ RBM with TAP formula-based gradient which supports deterministic training<br /><
 ### \_\_init\_\_
 ```py
 
-def __init__(self, layer_list, init_lr_EMF=0.1, tolerance_EMF=0.01, max_iters_EMF=100, num_persistent_samples=0)
+def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-07, max_iters_EMF=100, num_persistent_samples=0)
 
 ```
 
 
 
-Create a TAP RBM model.<br /><br />Notes:<br /> ~ Only 2-layer models currently supported.<br /><br />Args:<br /> ~ layer_list: A list of layers objects.<br /><br /> ~ EMF computation parameters:<br /> ~  ~ init_lr float: initial learning rate which is halved whenever necessary to enforce descent.<br /> ~  ~ tol float: tolerance for quitting minimization.<br /> ~  ~ max_iters: maximum gradient decsent steps<br /> ~  ~ number of persistent magnetization parameters to keep as seeds for gradient descent.<br /> ~  ~  ~ 0 implies we use a random seed each iteration<br /><br />Returns:<br /> ~ model: A TAP RBM model.
+Create a TAP RBM model.<br /><br />Notes:<br /> ~ Only 2-layer models currently supported.<br /><br />Args:<br /> ~ layer_list: A list of layers objects.<br /> ~ terms: number of terms to use in the TAP expansion (#TODO: deprecate this attribute when we turn tap training into a method and use tap1,tap2,tap3 as methods)<br /><br /> ~ EMF computation parameters:<br /> ~  ~ init_lr float: initial learning rate which is halved whenever necessary to enforce descent.<br /> ~  ~ tol float: tolerance for quitting minimization.<br /> ~  ~ max_iters: maximum gradient decsent steps<br /> ~  ~ number of persistent magnetization parameters to keep as seeds for gradient descent.<br /> ~  ~  ~ 0 implies we use a random seed each iteration<br /><br />Returns:<br /> ~ model: A TAP RBM model.
 
 
 ### deterministic\_iteration
@@ -41,10 +41,28 @@ def deterministic_iteration(self, n, state, beta=None, clamped=[])
 Perform multiple deterministic (maximum probability) updates<br />in alternating layers.<br />state -> new state<br /><br />Notes:<br /> ~ Returns the layer units that maximize the probability<br /> ~ conditioned on adjacent layers,<br /> ~ x_i = argmax P(x_i | x_(i-1), x_(i+1))<br /><br />Args:<br /> ~ n (int): number of steps.<br /> ~ state (State object): the current state of each layer<br /> ~ beta (optional, tensor (batch_size, 1)): Inverse temperatures<br /> ~ clamped (list): list of layer indices to clamp<br /><br />Returns:<br /> ~ new state
 
 
+### gamma\_MF
+```py
+
+def gamma_MF(self, m)
+
+```
+
+
+
 ### gamma\_TAP2
 ```py
 
-def gamma_TAP2(self, m, w, a, b)
+def gamma_TAP2(self, m)
+
+```
+
+
+
+### gamma\_TAP3
+```py
+
+def gamma_TAP3(self, m)
 
 ```
 
@@ -62,16 +80,61 @@ def get_config(self) -> dict
 Get a configuration for the model.<br /><br />Notes:<br /> ~ Includes metadata on the layers.<br /><br />Args:<br /> ~ None<br /><br />Returns:<br /> ~ A dictionary configuration for the model.
 
 
-### gibbs\_free\_energy\_TAP2
+### gibbs\_free\_energy
 ```py
 
-def gibbs_free_energy_TAP2(self, seed=None, init_lr=0.1, tol=0.0001, max_iters=500)
+def gibbs_free_energy(self, seed=None, init_lr=0.1, tol=0.0001, max_iters=50, terms=2)
 
 ```
 
 
 
-Compute the Gibbs free engergy of the model according to the TAP<br />expansion around infinite temperature to second order.<br /><br />If the energy is:<br />'''<br /> ~ E(v, h) := -\langle a,v angle - \langle b,h angle - \langle v,W \cdot h angle, with state probability distribution:<br /> ~ P(v,h)  := 1/\sum_{v,h} \exp{-E(v,h)} * \exp{-E(v,h)}, and the marginal<br /> ~ P(v) ~ := \sum_{h} P(v,h)<br />'''<br />Then the Gibbs free energy is:<br />'''<br /> ~ F(v) := -log\sum_{v,h} \exp{-E(v,h)}<br />'''<br />We add an auxiliary local field q, and introduce the inverse temperature variable eta to define<br />'''<br /> ~ eta F(v;q) := -log\sum_{v,h} \exp{-eta E(v,h) + eta \langle q, v angle}<br />'''<br />Let \Gamma(m) be the Legendre transform of F(v;q) as a function of q<br />The TAP formula is Taylor series of \Gamma in eta, around eta=0.<br />Setting eta=1 and regarding the first two terms of the series as an approximation of \Gamma[m],<br />we can minimize \Gamma in m to obtain an approximation of F(v;q=0) = F(v)<br /><br />This implementation uses gradient descent from a random starting location to minimize the function<br /><br />Args:<br /> ~ seed 'None' or Magnetization: initial seed for the minimization routine.<br /> ~  ~  ~  ~  ~  ~  ~  ~   Chosing 'None' will result in a random seed<br /> ~ init_lr float: initial learning rate which is halved whenever necessary to enforce descent.<br /> ~ tol float: tolerance for quitting minimization.<br /> ~ max_iters: maximum gradient decsent steps<br /><br />Returns:<br /> ~ tuple (magnetization, TAP2-approximated Gibbs free energy)<br /> ~  ~   (Magnetization, float)
+Compute the Gibbs free engergy of the model according to the TAP<br />expansion around infinite temperature to second order.<br /><br />If the energy is:<br />'''<br /> ~ E(v, h) := -\langle a,v angle - \langle b,h angle - \langle v,W \cdot h angle, with state probability distribution:<br /> ~ P(v,h)  := 1/\sum_{v,h} \exp{-E(v,h)} * \exp{-E(v,h)}, and the marginal<br /> ~ P(v) ~ := \sum_{h} P(v,h)<br />'''<br />Then the Gibbs free energy is:<br />'''<br /> ~ F(v) := -log\sum_{v,h} \exp{-E(v,h)}<br />'''<br />We add an auxiliary local field q, and introduce the inverse temperature variable eta to define<br />'''<br /> ~ eta F(v;q) := -log\sum_{v,h} \exp{-eta E(v,h) + eta \langle q, v angle}<br />'''<br />Let \Gamma(m) be the Legendre transform of F(v;q) as a function of q<br />The TAP formula is Taylor series of \Gamma in eta, around eta=0.<br />Setting eta=1 and regarding the first two terms of the series as an approximation of \Gamma[m],<br />we can minimize \Gamma in m to obtain an approximation of F(v;q=0) = F(v)<br /><br />This implementation uses gradient descent from a random starting location to minimize the function<br /><br />Args:<br /> ~ seed 'None' or Magnetization: initial seed for the minimization routine.<br /> ~  ~  ~  ~  ~  ~  ~  ~   Chosing 'None' will result in a random seed<br /> ~ init_lr float: initial learning rate which is halved whenever necessary to enforce descent.<br /> ~ tol float: tolerance for quitting minimization.<br /> ~ max_iters: maximum gradient decsent steps.<br /> ~ terms: number of terms to use (1, 2, or 3 allowed)<br /><br />Returns:<br /> ~ tuple (magnetization, TAP-approximated Gibbs free energy)<br /> ~  ~   (Magnetization, float)
+
+
+### grad\_a\_gamma
+```py
+
+def grad_a_gamma(self, m, w, a, b)
+
+```
+
+
+
+### grad\_b\_gamma
+```py
+
+def grad_b_gamma(self, m, w, a, b)
+
+```
+
+
+
+### grad\_w\_gamma\_MF
+```py
+
+def grad_w_gamma_MF(self, m, w, a, b)
+
+```
+
+
+
+### grad\_w\_gamma\_TAP2
+```py
+
+def grad_w_gamma_TAP2(self, m, w, a, b)
+
+```
+
+
+
+### grad\_w\_gamma\_TAP3
+```py
+
+def grad_w_gamma_TAP3(self, m, w, a, b)
+
+```
+
 
 
 ### gradient
@@ -113,13 +176,13 @@ Compute the joint energy of the model based on a state.<br /><br />Args:<br /> ~
 ### marginal\_free\_energy
 ```py
 
-def marginal_free_energy(self, v, w, a, b)
+def marginal_free_energy(self, data)
 
 ```
 
 
 
-'''<br />-\log \sum_h \exp{-E(v,h)}<br />'''
+Compute the marginal free energy of the model.<br /><br />If the energy is:<br />E(v, h) = -\sum_i a_i(v_i) - \sum_j b_j(h_j) - \sum_{ij} W_{ij} v_i h_j<br />Then the marginal free energy is:<br />F(v) =  -\sum_i a_i(v_i) - \sum_j \log \int dh_j \exp(b_j(h_j) - \sum_i W_{ij} v_i)<br />This can be extended to a deep model by a sum over all hidden states<br /><br />Args:<br /> ~ data (State object): The current state of each layer.<br /><br />Returns:<br /> ~ tensor (batch_size, ): Marginal free energies.
 
 
 ### markov\_chain
@@ -189,7 +252,7 @@ Save a model to an open HDFStore.<br /><br />Notes:<br /> ~ Performs an IO opera
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, verbose=False, rename=False)
+def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
 
 ```
 

--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -30,7 +30,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
     rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=0,
-                              tolerance_EMF=1e-4, max_iters_EMF=25)
+                              tolerance_EMF=1e-4, max_iters_EMF=25, terms=2)
     rbm.initialize(data, 'glorot_normal')
 
     perf  = fit.ProgressMonitor(data,

--- a/examples/example_util.py
+++ b/examples/example_util.py
@@ -68,7 +68,7 @@ def show_reconstructions(rbm, v_data, fit, show_plot):
 
 def compute_fantasy_particles(rbm, v_data, fit):
     random_samples = rbm.random(v_data)
-    model_state = State.from_visible(v_data, rbm)
+    model_state = State.from_visible(random_samples, rbm)
     sampler = fit.DrivenSequentialMC(rbm)
     sampler.set_negative_state(model_state)
     sampler.update_negative_state(1000)

--- a/paysage/backends/python_backend/matrix.py
+++ b/paysage/backends/python_backend/matrix.py
@@ -811,7 +811,6 @@ def outer(x: T.Tensor, y: T.Tensor) -> T.Tensor:
     """
     return numpy.outer(x,y)
 
-
 class BroadcastError(ValueError):
     """
     BroadcastError exception:
@@ -845,7 +844,7 @@ def broadcast(vec: T.Tensor, matrix: T.Tensor) -> T.Tensor:
         return numpy.broadcast_to(vec, shape(matrix))
     except ValueError:
         raise BroadcastError('cannot broadcast vector of dimension {} \
-onto matrix of dimension {}'.format(shape(vec), shape(matrix)))
+        onto matrix of dimension {}'.format(shape(vec), shape(matrix)))
 
 def add(a: T.Tensor, b: T.Tensor) -> T.Tensor:
     """

--- a/paysage/backends/python_backend/matrix.py
+++ b/paysage/backends/python_backend/matrix.py
@@ -299,6 +299,20 @@ def reshape(tensor: T.Tensor, newshape: T.Tuple[int]) -> T.Tensor:
     """
     return numpy.reshape(tensor, newshape)
 
+def unsqueeze(tensor: T.Tensor, axis: int) -> T.Tensor:
+    """
+    Return tensor with a new axis inserted.
+
+    Args:
+        tensor: A tensor.
+        axis: The desired axis.
+
+    Returns:
+        tensor: A tensor with the new axis inserted.
+
+    """
+    return numpy.expand_dims(tensor, axis)
+
 def dtype(tensor: T.Tensor) -> type:
     """
     Return the type of the tensor.

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -309,6 +309,20 @@ def reshape(tensor: T.FloatTensor,
     """
     return tensor.view(*newshape)
 
+def unsqueeze(tensor: T.Tensor, axis: int) -> T.Tensor:
+    """
+    Return tensor with a new axis inserted.
+
+    Args:
+        tensor: A tensor.
+        axis: The desired axis.
+
+    Returns:
+        tensor: A tensor with the new axis inserted.
+
+    """
+    return torch.unsqueeze(tensor, axis)
+
 def dtype(tensor: T.FloatTensor) -> type:
     """
     Return the type of the tensor.

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -942,7 +942,7 @@ def broadcast(vec: T.FloatTensor, matrix: T.FloatTensor) -> T.FloatTensor:
             return vec.expand(matrix.size(0), matrix.size(1))
     except ValueError:
         raise BroadcastError('cannot broadcast vector of dimension {} \
-onto matrix of dimension {}'.format(shape(vec), shape(matrix)))
+              onto matrix of dimension {}'.format(shape(vec), shape(matrix)))
 
 def add(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
     """

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -25,7 +25,7 @@ class TAP_rbm(model.Model):
 
     """
 
-    def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-2, max_iters_EMF=100, num_persistent_samples=0):
+    def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-7, max_iters_EMF=100, num_persistent_samples=0):
         """
         Create a TAP rbm model.
 
@@ -372,6 +372,6 @@ class TAP_rbm(model.Model):
         grad.layers[0] = layers.IntrinsicParamsBernoulli(da + da_EMF)
         grad.layers[1] = layers.IntrinsicParamsBernoulli(db + db_EMF)
 
-        score = be.accumulate(self.marginal_free_energy, vdata)
-        print(score / batch_size + EMF)
+        #score = be.accumulate(self.marginal_free_energy, vdata)
+        #print(-score / batch_size + EMF)
         return grad

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -345,7 +345,7 @@ class TAP_rbm(model.Model):
         db_EMF = self.grad_b_gamma(m,w,a,b)
 
         # compute average grad_F_marginal over the minibatch
-        intermediate = be.expit(be.dot(data_state.units[0],w) + b)
+        intermediate = be.expit(be.add(be.unsqueeze(b,0), be.dot(data_state.units[0], w)))
 
         da = be.mean(data_state.units[0], axis=0)
         db = be.mean(intermediate, axis=0)

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -25,7 +25,7 @@ class TAP_rbm(model.Model):
 
     """
 
-    def __init__(self, layer_list, init_lr_EMF=0.1, tolerance_EMF=1e-2, max_iters_EMF=100, num_persistent_samples=0):
+    def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-2, max_iters_EMF=100, num_persistent_samples=0):
         """
         Create a TAP rbm model.
 
@@ -34,6 +34,7 @@ class TAP_rbm(model.Model):
 
         Args:
             layer_list: A list of layers objects.
+            terms: number of terms to use in the TAP expansion (#TODO: deprecate this attribute when we turn tap training into a method and use tap1,tap2,tap3 as methods)
 
             EMF computation parameters:
                 init_lr float: initial learning rate which is halved whenever necessary to enforce descent.
@@ -55,8 +56,12 @@ class TAP_rbm(model.Model):
             self.persistent_samples.append(None)
         self.tap_seed = None
 
+        if terms != 1 and terms != 2 and terms != 3:
+            raise ValueError("Must specify one, two, or three terms in TAP expansion training method")
+        self.terms = terms
 
-    def gibbs_free_energy_TAP3(self, seed=None, init_lr=0.1, tol=1e-4, max_iters=500):
+
+    def gibbs_free_energy(self, seed=None, init_lr=0.1, tol=1e-4, max_iters=50, terms=2):
         """
         Compute the Gibbs free engergy of the model according to the TAP
         expansion around infinite temperature to second order.
@@ -87,67 +92,91 @@ class TAP_rbm(model.Model):
                                           Chosing 'None' will result in a random seed
             init_lr float: initial learning rate which is halved whenever necessary to enforce descent.
             tol float: tolerance for quitting minimization.
-            max_iters: maximum gradient decsent steps
+            max_iters: maximum gradient decsent steps.
+            terms: number of terms to use (1, 2, or 3 allowed)
 
         Returns:
             tuple (magnetization, TAP3-approximated Gibbs free energy)
                   (Magnetization, float)
 
         """
+        if terms != 1 and terms != 2 and terms != 3:
+            raise ValueError("Must specify one, two, or three terms in TAP expansion training method")
 
         w = self.weights[0].int_params.matrix
         a = self.layers[0].int_params.loc
         b = self.layers[1].int_params.loc
 
+        # Mean field derivatives
+        def grad_v_gamma_MF(m, w, a):
+            return be.log(be.divide(1.0 - m.v, m.v)) - a - be.dot(w, m.h)
+        def grad_h_gamma_MF(m, w, b):
+            return be.log(be.divide(1.0 - m.h, m.h)) - b - be.dot(m.v,w)
+
+        # MF plus Onsager reaction term
         def grad_v_gamma_TAP2(m, w, a):
             m_h_quad = m.h - be.square(m.h)
             ww = be.square(w)
             return be.log(be.divide(1.0 - m.v, m.v)) - a - be.dot(w, m.h) - \
                    be.multiply(0.5 - m.v,be.dot(ww, m_h_quad))
-
         def grad_h_gamma_TAP2(m, w, b):
             m_v_quad = m.v - be.square(m.v)
             ww = be.square(w)
             return be.log(be.divide(1.0 - m.h, m.h)) - b - be.dot(m.v,w) - \
                    be.multiply(be.dot(m_v_quad,ww),0.5 - m.h)
 
+        # Third order TAP expansion gradients
         def grad_v_gamma_TAP3(m, w, a):
             m_h_quad = m.h - be.square(m.h)
             ww = be.square(w)
             www = be.multiply(ww,w)
             return be.log(be.divide(1.0 - m.v, m.v)) - a - be.dot(w, m.h) - \
                    be.multiply(0.5 - m.v,be.dot(ww, m_h_quad)) - \
-                   (4.0/3.0)*be.multiply(0.5 - 3.0*m.v + 3.0*be.square(m.v), be.dot(www,be.multiply(0.5 - m.h, m_h_quad)))
-
+                   (4.0/3.0)*be.multiply(0.5 - 3.0*m.v + 3.0*be.square(m.v),\
+                   be.dot(www,be.multiply(0.5 - m.h, m_h_quad)))
         def grad_h_gamma_TAP3(m, w, b):
             m_v_quad = m.v - be.square(m.v)
             ww = be.square(w)
             www = be.multiply(ww,w)
             return be.log(be.divide(1.0 - m.h, m.h)) - b - be.dot(m.v,w) - \
                    be.multiply(be.dot(m_v_quad,ww),0.5 - m.h) - \
-                   (4.0/3.0)*be.multiply(be.dot(be.multiply(0.5 - m.v, m_v_quad),www),0.5 - 3.0*m.h + 3.0*be.square(m.h))
+                   (4.0/3.0)*be.multiply(be.dot(be.multiply(0.5 - m.v, m_v_quad),www),\
+                   0.5 - 3.0*m.h + 3.0*be.square(m.h))
 
-        def minimize_gamma_GD(w, a, b, m, init_lr, tol, max_iters):
+        def minimize_gamma_GD(w, a, b, m, init_lr, tol, max_iters, terms):
             """
             Simple gradient descent routine to minimize Gamma
 
             Warning: this function modifies seed to avoid an extra copy and allocation
 
             """
+            if terms == 1:
+                gamma = self.gamma_MF
+                grad_v_gamma = grad_v_gamma_MF
+                grad_h_gamma = grad_h_gamma_MF
+            elif terms == 2:
+                gamma = self.gamma_TAP2
+                grad_v_gamma = grad_v_gamma_TAP2
+                grad_h_gamma = grad_h_gamma_TAP2
+            elif terms == 3:
+                gamma = self.gamma_MF
+                grad_v_gamma = grad_v_gamma_TAP3
+                grad_h_gamma = grad_h_gamma_TAP3
+
             eps = 1e-6
             its = 0
             lr = init_lr
-            gam = self.gamma_TAP3(m, w, a, b)
+            gam = gamma(m, w, a, b)
 
             while (its < max_iters):
                 its += 1
-                m_provisional = Magnetization(m.v - lr*grad_v_gamma_TAP3(m, w, a),
-                                              m.h - lr*grad_h_gamma_TAP3(m, w, b))
+                m_provisional = Magnetization(m.v - lr*grad_v_gamma(m, w, a),
+                                              m.h - lr*grad_h_gamma(m, w, b))
                 # Warning: in general a lot of clipping gets done here
                 be.clip_inplace(m_provisional.v, eps, 1.0-eps)
                 be.clip_inplace(m_provisional.h, eps, 1.0-eps)
 
-                gam_provisional = self.gamma_TAP3(m_provisional, w, a, b)
+                gam_provisional = gamma(m_provisional, w, a, b)
                 if (gam - gam_provisional < 0):
                     lr *= 0.5
                     if (lr < 1e-10):
@@ -199,8 +228,16 @@ class TAP_rbm(model.Model):
                 0.99 * be.float_tensor(be.rand((num_hidden_units,))) + 0.005
             )
 
-        return minimize_gamma_GD(w, a, b, seed, init_lr, tol, max_iters)
+        return minimize_gamma_GD(w, a, b, seed, init_lr, tol, max_iters, terms)
         #return minimize_gamma_constraint_sat(w, a, b, seed, tol, max_iters)
+
+    # The Legendre transform of F(v;q) as a function of q according to Mean Field approximation
+    # specialized to the RBM case
+    def gamma_MF(self, m, w, a, b):
+        return \
+            be.tsum(be.multiply(m.v, be.log(m.v)) + be.multiply(1.0 - m.v, be.log(1.0 - m.v))) + \
+            be.tsum(be.multiply(m.h, be.log(m.h)) + be.multiply(1.0 - m.h, be.log(1.0 - m.h))) - \
+            be.dot(a,m.v) - be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h))
 
     # The Legendre transform of F(v;q) as a function of q according to TAP expansion 2 terms
     # specialized to the RBM case
@@ -239,6 +276,31 @@ class TAP_rbm(model.Model):
         """
         return -be.dot(a,v) - be.tsum(be.logaddexp((b + be.dot(v,w)), be.zeros_like(b)))
 
+    def grad_a_gamma_MF(self, m, w, a, b):
+        return -m.v
+    def grad_b_gamma_MF(self, m, w, a, b):
+        return -m.h
+    def grad_w_gamma_MF(self, m, w, a, b):
+        return -be.outer(m.v, m.h)
+
+    def grad_a_gamma_TAP2(self, m, w, a, b):
+        return -m.v
+    def grad_b_gamma_TAP2(self, m, w, a, b):
+        return -m.h
+    def grad_w_gamma_TAP2(self, m, w, a, b):
+        m_v_quad = m.v - be.square(m.v)
+        m_h_quad = m.h - be.square(m.h)
+        return -be.outer(m.v, m.h) - be.multiply(w, be.outer(m_v_quad, m_h_quad))
+
+    def grad_a_gamma_TAP3(self, m, w, a, b):
+        return -m.v
+    def grad_b_gamma_TAP3(self, m, w, a, b):
+        return -m.h
+    def grad_w_gamma_TAP3(self, m, w, a, b):
+        m_v_quad = m.v - be.square(m.v)
+        m_h_quad = m.h - be.square(m.h)
+        return -be.outer(m.v, m.h) - be.multiply(w, be.outer(m_v_quad, m_h_quad))
+
     def gradient(self, vdata, vmodel):
         """
         Gradient of -\ln P(v) with respect to the weights and biases
@@ -249,32 +311,44 @@ class TAP_rbm(model.Model):
         a = self.layers[0].int_params.loc
         b = self.layers[1].int_params.loc
 
+        if self.terms == 1:
+             grad_a_gamma = self.grad_a_gamma_MF
+             grad_b_gamma = self.grad_b_gamma_MF
+             grad_w_gamma = self.grad_w_gamma_MF
+        elif self.terms == 2:
+             grad_a_gamma = self.grad_a_gamma_TAP2
+             grad_b_gamma = self.grad_b_gamma_TAP2
+             grad_w_gamma = self.grad_w_gamma_TAP2
+        elif self.terms == 3:
+             grad_a_gamma = self.grad_a_gamma_TAP3
+             grad_b_gamma = self.grad_b_gamma_TAP3
+             grad_w_gamma = self.grad_w_gamma_TAP3
+
         # compute the TAP3 approximation to the Gibbs free energy:
         EMF = 1e6
         m = None
         if len(self.persistent_samples) == 0: # random seed
-                (m,EMF) = self.gibbs_free_energy_TAP3(m,
-                                                      self.init_lr_EMF,
-                                                      self.tolerance_EMF,
-                                                      self.max_iters_EMF)
+                (m,EMF) = self.gibbs_free_energy(m,
+                                                 self.init_lr_EMF,
+                                                 self.tolerance_EMF,
+                                                 self.max_iters_EMF,
+                                                 self.terms)
         else:
             best_EMF = 1e7
             for s in range(len(self.persistent_samples)): # persistent seeds
-                (self.persistent_samples[s],EMF) = self.gibbs_free_energy_TAP3(self.persistent_samples[s],
-                                                                               self.init_lr_EMF,
-                                                                               self.tolerance_EMF,
-                                                                               self.max_iters_EMF)
+                (self.persistent_samples[s],EMF) = self.gibbs_free_energy(self.persistent_samples[s],
+                                                                          self.init_lr_EMF,
+                                                                          self.tolerance_EMF,
+                                                                          self.max_iters_EMF,
+                                                                          self.terms)
                 if EMF < best_EMF:
                     best_EMF = EMF
                     m = self.persistent_samples[s]
 
         # Compute the gradients at this minimizing magnetization
-        m_v_quad = m.v - be.square(m.v)
-        m_h_quad = m.h - be.square(m.h)
-
-        dw_EMF = -be.outer(m.v, m.h) - be.multiply(w, be.outer(m_v_quad, m_h_quad))
-        da_EMF = -m.v
-        db_EMF = -m.h
+        dw_EMF = grad_w_gamma(m,w,a,b)
+        da_EMF = grad_a_gamma(m,w,a,b)
+        db_EMF = grad_b_gamma(m,w,a,b)
 
         # compute average grad_F_marginal over the minibatch
         intermediate = be.expit(be.dot(vdata,w) + b)
@@ -282,8 +356,6 @@ class TAP_rbm(model.Model):
         da = be.mean(vdata, axis=0)
         db = be.mean(intermediate, axis=0)
         batch_size = be.shape(vdata)[0]
-        # This is the same as \sum_{i} vdata[i] \outer intermediate[i]
-        # TODO: is this efficient?
         dw = be.dot(be.transpose(vdata), intermediate) / batch_size
 
         grad = gu.Gradient(

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -281,18 +281,6 @@ class TAP_rbm(model.Model):
             0.5 * be.dot(m_v_quad, be.dot(ww, m_h_quad)) - \
             (4.0/3.0) * be.tsum(be.multiply(alias2, be.multiply(alias1, www)))
 
-    def marginal_free_energy(self, v):
-        """
-        '''
-        -\log \sum_h \exp{-E(v,h)}
-        '''
-        """
-        # alias weights and biases
-        w = self.weights[0].int_params[0]
-        a = self.layers[0].int_params[0]
-        b = self.layers[1].int_params[0]
-        return -be.dot(a,v) - be.tsum(be.logaddexp((b + be.dot(v,w)), be.zeros_like(b)))
-
     def grad_a_gamma(self, m, w, a, b):
         return -m.v
     def grad_b_gamma(self, m, w, a, b):

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -257,7 +257,7 @@ class TAP_rbm(model.Model):
         return \
             be.tsum(be.multiply(m.v, be.log(m.v)) + be.multiply(1.0 - m.v, be.log(1.0 - m.v))) + \
             be.tsum(be.multiply(m.h, be.log(m.h)) + be.multiply(1.0 - m.h, be.log(1.0 - m.h))) - \
-            be.dot(a,m.v) - be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h)) - \
+            be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h)) - \
             0.5 * be.dot(m_v_quad, be.dot(ww, m_h_quad))
 
     # The Legendre transform of F(v;q) as a function of q according to TAP expansion 3 terms
@@ -277,7 +277,7 @@ class TAP_rbm(model.Model):
         return \
             be.tsum(be.multiply(m.v, be.log(m.v)) + be.multiply(1.0 - m.v, be.log(1.0 - m.v))) + \
             be.tsum(be.multiply(m.h, be.log(m.h)) + be.multiply(1.0 - m.h, be.log(1.0 - m.h))) - \
-            be.dot(a,m.v) - be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h)) - \
+            be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h)) - \
             0.5 * be.dot(m_v_quad, be.dot(ww, m_h_quad)) - \
             (4.0/3.0) * be.tsum(be.multiply(alias2, be.multiply(alias1, www)))
 

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -125,7 +125,7 @@ class TAP_rbm(model.Model):
             www = be.multiply(ww,w)
             return be.log(be.divide(1.0 - m.h, m.h)) - b - be.dot(m.v,w) - \
                    be.multiply(be.dot(m_v_quad,ww),0.5 - m.h) - \
-                   (4.0/3.0)*be.multiply(be.dot(be.multiply(0.5 - m.h, m_h_quad),www),0.5 - 3.0*m.h + 3.0*be.square(m.h))
+                   (4.0/3.0)*be.multiply(be.dot(be.multiply(0.5 - m.v, m_v_quad),www),0.5 - 3.0*m.h + 3.0*be.square(m.h))
 
         def minimize_gamma_GD(w, a, b, m, init_lr, tol, max_iters):
             """
@@ -222,13 +222,14 @@ class TAP_rbm(model.Model):
         m_h_quad = m.h - be.square(m.h)
         ww = be.square(w)
         www = be.multiply(ww,w)
-        temp = be.multiply(www, be.multiply(0.5 - m.v,m_v_quad))
+        alias1 = be.unsqueeze(be.multiply(0.5 - m.v, m_v_quad),1)
+        alias2 = be.unsqueeze(be.multiply(0.5 - m.h, m_h_quad),0)
         return \
             be.tsum(be.multiply(m.v, be.log(m.v)) + be.multiply(1.0 - m.v, be.log(1.0 - m.v))) + \
             be.tsum(be.multiply(m.h, be.log(m.h)) + be.multiply(1.0 - m.h, be.log(1.0 - m.h))) - \
             be.dot(a,m.v) - be.dot(b,m.h) - be.dot(m.v, a + be.dot(w,m.h)) - \
             0.5 * be.dot(m_v_quad, be.dot(ww, m_h_quad)) - \
-            (4.0/3.0) * be.tsum(be.multiply(temp,be.multiply(0.5-m_h, m_h_quad)))
+            (4.0/3.0) * be.tsum(be.multiply(alias2, be.multiply(alias1, www)))
 
     def marginal_free_energy(self, v, w, a, b):
         """

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -292,7 +292,9 @@ class TAP_rbm(model.Model):
     def grad_w_gamma_TAP3(self, m, w, a, b):
         m_v_quad = m.v - be.square(m.v)
         m_h_quad = m.h - be.square(m.h)
-        return -be.outer(m.v, m.h) - be.multiply(w, be.outer(m_v_quad, m_h_quad))
+        ww = be.square(w)
+        return -be.outer(m.v, m.h) - be.multiply(w, be.outer(m_v_quad, m_h_quad)) - \
+               4.0 * be.multiply(ww, be.outer(be.multiply(0.5 - m.v, m_v_quad), be.multiply(0.5 - m.h, m_h_quad)))
 
     def gradient(self, vdata, vmodel):
         """

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -79,6 +79,28 @@ def test_transpose():
     assert torch_matrix.allclose(torch_y_T, torch_py_y_T), \
     "torch -> python -> torch failure: transpose"
 
+def test_unsqueeze():
+
+    shape = (100,)
+
+    py_rand.set_seed()
+    py_x = py_rand.rand(shape)
+    torch_x = torch_matrix.float_tensor(py_x)
+
+    py_x_col = py_matrix.unsqueeze(py_x,1)
+    torch_x_col = torch_matrix.unsqueeze(torch_x,1)
+    py_x_row = py_matrix.unsqueeze(py_x,0)
+    torch_x_row = torch_matrix.unsqueeze(torch_x,0)
+
+    assert_close(py_x_col, torch_x_col, \
+    "python->torch failure: unsqueeze to col vector")
+
+    assert_close(py_x_row, torch_x_row, \
+    "python->torch failure: unsqueeze to row vector")
+
+    assert py_matrix.shape(py_x_col) == py_matrix.shape(py_x_row.transpose())
+    assert torch_matrix.shape(torch_x_col) == torch_matrix.shape(torch_matrix.transpose(torch_x_row))
+
 def test_zeros():
     shape = (100, 100)
 


### PR DESCRIPTION
Implements TAP3 formulas. Using TAP1 (Mean Field), TAP2 (default), TAP3 are all options now. 

It seems that TAP2 still works better at least at the start for RBMs trained on MNIST.