### PR TITLE
Better random

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -609,13 +609,13 @@ Return the number of dimensions of a tensor.<br /><br />Args:<br /> ~ tensor: A 
 ### norm
 ```py
 
-def norm(x: numpy.ndarray) -> float
+def norm(x: numpy.ndarray, axis: int=None, keepdims: bool=False) -> Union[numpy.float32, numpy.ndarray]
 
 ```
 
 
 
-Return the L2 norm of a tensor.<br /><br />Args:<br /> ~ x: A tensor.<br /><br />Returns:<br /> ~ float: The L2 norm of the tensor<br /> ~  ~    (i.e., the sqrt of the sum of the squared elements).
+Return the L2 norm of a tensor.<br /><br />Args:<br /> ~ x: A tensor.<br /> ~ axis (optional): the axis for taking the norm<br /> ~ keepdims (optional): If this is set to true, the dimension of the tensor<br /> ~  ~  ~  ~  ~  ~  is unchanged. Otherwise, the reduced axis is removed<br /> ~  ~  ~  ~  ~  ~  and the dimension of the array is 1 less.<br /><br />Returns:<br /> ~ if axis is none:<br /> ~  ~ float: The L2 norm of the tensor<br /> ~  ~    (i.e., the sqrt of the sum of the squared elements).<br /> ~ else:<br /> ~  ~ tensor: The L2 norm along the specified axis.
 
 
 ### normalize
@@ -1084,6 +1084,18 @@ def tsum(x: numpy.ndarray, axis: int=None, keepdims: bool=False) -> Union[numpy.
 
 
 Return the sum of the elements of a tensor along the specified axis.<br /><br />Args:<br /> ~ x: A float or tensor.<br /> ~ axis (optional): The axis for taking the sum.<br /> ~ keepdims (optional): If this is set to true, the dimension of the tensor<br /> ~  ~  ~  ~  ~  ~  is unchanged. Otherwise, the reduced axis is removed<br /> ~  ~  ~  ~  ~  ~  and the dimension of the array is 1 less.<br /><br />Returns:<br /> ~ if axis is None:<br /> ~  ~ float: The overall sum of the elements in the tensor<br /> ~ else:<br /> ~  ~ tensor: The sum of the tensor along the specified axis.
+
+
+### unsqueeze
+```py
+
+def unsqueeze(tensor: numpy.ndarray, axis: int) -> numpy.ndarray
+
+```
+
+
+
+Return tensor with a new axis inserted.<br /><br />Args:<br /> ~ tensor: A tensor.<br /> ~ axis: The desired axis.<br /><br />Returns:<br /> ~ tensor: A tensor with the new axis inserted.
 
 
 ### var

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -97,7 +97,7 @@ Serves up minibatches from an HDFStore.<br />The validation set is taken as the 
 ### \_\_init\_\_
 ```py
 
-def __init__(self, filename, key, batch_size, train_fraction=0.9, transform=<function float_tensor at 0x103a0aea0>)
+def __init__(self, filename, key, batch_size, train_fraction=0.9, transform=<function float_tensor at 0x117b2e158>)
 
 ```
 

--- a/docs/fit.md
+++ b/docs/fit.md
@@ -5,7 +5,7 @@ Stochastic gradient descent with minibatches
 ### \_\_init\_\_
 ```py
 
-def __init__(self, model, batch, optimizer, epochs, method=<function persistent_contrastive_divergence at 0x1099db620>, sampler=<class 'paysage.fit.SequentialMC'>, mcsteps=1, monitor=None)
+def __init__(self, model, batch, optimizer, epochs, method=<function persistent_contrastive_divergence at 0x118317510>, sampler=<class 'paysage.fit.SequentialMC'>, mcsteps=1, monitor=None)
 
 ```
 

--- a/docs/gradient_util.md
+++ b/docs/gradient_util.md
@@ -93,7 +93,7 @@ Apply an in place function entrywise over the zip of two Gradient objects.<br />
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
+def namedtuple(typename, field_names, verbose=False, rename=False)
 
 ```
 

--- a/docs/initialize.md
+++ b/docs/initialize.md
@@ -1,0 +1,1 @@
+# Documentation for Initialize (initialize.py)

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -219,7 +219,7 @@ def random(self, array_or_shape)
 
 
 
-Generate a random sample with the same type as the layer.<br />For an Exponential layer, draws from the exponential distribution<br />with mean 1 (i.e., Expo(1)).<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
+Generate a random sample with the same type as the layer.<br />For an Exponential layer, draws from the exponential distribution<br />with the rate determined by the params attribute.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
 
 
 ### rescale
@@ -479,7 +479,7 @@ def random(self, array_or_shape)
 
 
 
-Generate a random sample with the same type as the layer.<br />For a Bernoulli layer, draws 0 or 1 with equal probability.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
+Generate a random sample with the same type as the layer.<br />For a Bernoulli layer, draws 0 or 1 with the field determined<br />by the params attribute.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
 
 
 ### rescale
@@ -739,7 +739,7 @@ def random(self, array_or_shape)
 
 
 
-Generate a random sample with the same type as the layer.<br />For a Gaussian layer, draws from the standard normal distribution N(0,1).<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
+Generate a random sample with the same type as the layer.<br />For a Gaussian layer, draws from a normal distribution<br />with the mean and variance determined from the params attribute.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
 
 
 ### rescale
@@ -1011,7 +1011,7 @@ def random(self, array_or_shape)
 
 
 
-Generate a random sample with the same type as the layer.<br />For an Ising layer, draws -1 or +1 with equal probablity.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
+Generate a random sample with the same type as the layer.<br />For an Ising layer, draws -1 or +1 with the field determined<br />by the params attribute.<br /><br />Used for generating initial configurations for Monte Carlo runs.<br /><br />Args:<br /> ~ array_or_shape (array or shape tuple):<br /> ~  ~ If tuple, then this is taken to be the shape.<br /> ~  ~ If array, then its shape is used.<br /><br />Returns:<br /> ~ tensor: Random sample with desired shape.
 
 
 ### rescale
@@ -1398,7 +1398,7 @@ def get(key)
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
+def namedtuple(typename, field_names, verbose=False, rename=False)
 
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -221,7 +221,7 @@ Get the value of the energy gap.<br /><br />Args:<br /> ~ None<br /><br />Return
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
+def namedtuple(typename, field_names, verbose=False, rename=False)
 
 ```
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,1 @@
+# Documentation for Models (models.py)

--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -149,7 +149,7 @@ Base class for the optimizer methods.
 ### \_\_init\_\_
 ```py
 
-def __init__(self, scheduler=<paysage.optimizers.PowerLawDecay object at 0x105d865c0>, tolerance=1e-07)
+def __init__(self, scheduler=<paysage.optimizers.PowerLawDecay object at 0x118306860>, tolerance=1e-07)
 
 ```
 
@@ -205,7 +205,7 @@ Vanilla gradient optimizer
 ### \_\_init\_\_
 ```py
 
-def __init__(self, stepsize=0.001, scheduler=<paysage.optimizers.PowerLawDecay object at 0x105d86630>, tolerance=1e-07, ascent=False)
+def __init__(self, stepsize=0.001, scheduler=<paysage.optimizers.PowerLawDecay object at 0x1183068d0>, tolerance=1e-07, ascent=False)
 
 ```
 
@@ -245,7 +245,7 @@ Stochastic gradient descent with momentum.<br />Qian, N. (1999).<br />On the mom
 ### \_\_init\_\_
 ```py
 
-def __init__(self, stepsize=0.001, momentum=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x105d866d8>, tolerance=1e-07, ascent=False)
+def __init__(self, stepsize=0.001, momentum=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x118306978>, tolerance=1e-07, ascent=False)
 
 ```
 
@@ -285,7 +285,7 @@ Stochastic gradient descent with RMSProp.<br />Geoffrey Hinton's Coursera Course
 ### \_\_init\_\_
 ```py
 
-def __init__(self, stepsize=0.001, mean_square_weight=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x105d86780>, tolerance=1e-07, ascent=False)
+def __init__(self, stepsize=0.001, mean_square_weight=0.9, scheduler=<paysage.optimizers.PowerLawDecay object at 0x1182a2b00>, tolerance=1e-07, ascent=False)
 
 ```
 
@@ -329,7 +329,7 @@ Stochastic gradient descent with Adaptive Moment Estimation algorithm.<br /><br 
 ### \_\_init\_\_
 ```py
 
-def __init__(self, stepsize=0.001, mean_weight=0.9, mean_square_weight=0.999, scheduler=<paysage.optimizers.PowerLawDecay object at 0x105d86828>, tolerance=1e-07, ascent=False)
+def __init__(self, stepsize=0.001, mean_weight=0.9, mean_square_weight=0.999, scheduler=<paysage.optimizers.PowerLawDecay object at 0x1182a2c18>, tolerance=1e-07, ascent=False)
 
 ```
 

--- a/docs/tap_machine.md
+++ b/docs/tap_machine.md
@@ -252,7 +252,7 @@ Save a model to an open HDFStore.<br /><br />Notes:<br /> ~ Performs an IO opera
 ### namedtuple
 ```py
 
-def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
+def namedtuple(typename, field_names, verbose=False, rename=False)
 
 ```
 

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -1565,7 +1565,7 @@ class ExponentialLayer(Layer):
             shape = array_or_shape
 
         r = self.rand(shape)
-        return be.div(self.params.loc, -be.log(r))
+        return be.divide(self.params.loc, -be.log(r))
 
 
 

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -686,10 +686,15 @@ class GaussianLayer(Layer):
 
         """
         try:
-            r = be.float_tensor(self.rand(be.shape(array_or_shape)))
-        except AttributeError:
-            r = be.float_tensor(self.rand(array_or_shape))
-        return r
+            shape = be.shape(array_or_shape)
+        except Exception:
+            shape = array_or_shape
+
+        mean = self.params.loc
+        var = be.exp(self.params.log_var)
+        r = self.rand(shape)
+
+        return be.add(mean, be.multiply(be.sqrt(var), r))
 
 
 ParamsIsing = namedtuple("ParamsIsing", ["loc"])
@@ -974,10 +979,13 @@ class IsingLayer(Layer):
 
         """
         try:
-            r = self.rand(be.shape(array_or_shape))
-        except AttributeError:
-            r = self.rand(array_or_shape)
-        return 2 * be.float_tensor(r < 0.5) - 1
+            shape = be.shape(array_or_shape)
+        except Exception:
+            shape = array_or_shape
+
+        r = self.rand(shape)
+        p = be.expit(be.broadcast(self.params.loc, r))
+        return 2 * be.float_tensor(r < p) - 1
 
 
 ParamsBernoulli = namedtuple("ParamsBernoulli", ["loc"])
@@ -1262,10 +1270,13 @@ class BernoulliLayer(Layer):
 
         """
         try:
-            r = self.rand(be.shape(array_or_shape))
-        except AttributeError:
-            r = self.rand(array_or_shape)
-        return be.float_tensor(r < 0.5)
+            shape = be.shape(array_or_shape)
+        except Exception:
+            shape = array_or_shape
+
+        r = self.rand(shape)
+        p = be.expit(be.broadcast(self.params.loc, r))
+        return be.float_tensor(r < p)
 
 
 ParamsExponential = namedtuple("ParamsExponential", ["loc"])
@@ -1549,10 +1560,13 @@ class ExponentialLayer(Layer):
 
         """
         try:
-            r = self.rand(be.shape(array_or_shape))
-        except AttributeError:
-            r = self.rand(array_or_shape)
-        return -be.log(r)
+            shape = be.shape(array_or_shape)
+        except Exception:
+            shape = array_or_shape
+
+        r = self.rand(shape)
+        return be.div(self.params.loc, -be.log(r))
+
 
 
 # ---- FUNCTIONS ----- #

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -672,7 +672,8 @@ class GaussianLayer(Layer):
     def random(self, array_or_shape):
         """
         Generate a random sample with the same type as the layer.
-        For a Gaussian layer, draws from the standard normal distribution N(0,1).
+        For a Gaussian layer, draws from a normal distribution
+        with the mean and variance determined from the params attribute.
 
         Used for generating initial configurations for Monte Carlo runs.
 
@@ -965,7 +966,8 @@ class IsingLayer(Layer):
     def random(self, array_or_shape):
         """
         Generate a random sample with the same type as the layer.
-        For an Ising layer, draws -1 or +1 with equal probablity.
+        For an Ising layer, draws -1 or +1 with the field determined
+        by the params attribute.
 
         Used for generating initial configurations for Monte Carlo runs.
 
@@ -1256,7 +1258,8 @@ class BernoulliLayer(Layer):
     def random(self, array_or_shape):
         """
         Generate a random sample with the same type as the layer.
-        For a Bernoulli layer, draws 0 or 1 with equal probability.
+        For a Bernoulli layer, draws 0 or 1 with the field determined
+        by the params attribute.
 
         Used for generating initial configurations for Monte Carlo runs.
 
@@ -1546,7 +1549,7 @@ class ExponentialLayer(Layer):
         """
         Generate a random sample with the same type as the layer.
         For an Exponential layer, draws from the exponential distribution
-        with mean 1 (i.e., Expo(1)).
+        with the rate determined by the params attribute.
 
         Used for generating initial configurations for Monte Carlo runs.
 


### PR DESCRIPTION
Chang the `layer.random` methods to draw from distributions determined by the `params` attributes rather than some standard distribution. This way, samples obtained from the `random` function are closer to the equilibrium distribution.