### PR TITLE
Gamma sampler

### DIFF
--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -44,7 +44,9 @@ def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
                           scheduler=optimizers.PowerLawDecay(0.1))
 
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
-                                                method='stochastic')
+                                                method='stochastic',
+                                                beta_std = 1.0,
+                                                beta_momentum = 0.0)
 
     cd = fit.SGD(rbm, data, opt, num_epochs, method=fit.pcd, sampler=sampler,
                  mcsteps=mc_steps, monitor=perf)
@@ -64,4 +66,4 @@ def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
     print("Done")
 
 if __name__ == "__main__":
-    example_mnist_grbm(show_plot = False)
+    example_mnist_grbm(show_plot = True)

--- a/examples/example_mnist_grbm.py
+++ b/examples/example_mnist_grbm.py
@@ -44,9 +44,7 @@ def example_mnist_grbm(paysage_path=None, num_epochs=10, show_plot=False):
                           scheduler=optimizers.PowerLawDecay(0.1))
 
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
-                                                method='stochastic',
-                                                beta_std = 1.0,
-                                                beta_momentum = 0.0)
+                                                method='stochastic')
 
     cd = fit.SGD(rbm, data, opt, num_epochs, method=fit.pcd, sampler=sampler,
                  mcsteps=mc_steps, monitor=perf)

--- a/examples/example_mnist_hopfield.py
+++ b/examples/example_mnist_hopfield.py
@@ -61,4 +61,4 @@ def example_mnist_hopfield(paysage_path=None, num_epochs=10, show_plot=False):
     print("Done")
 
 if __name__ == "__main__":
-    example_mnist_hopfield(show_plot = False)
+    example_mnist_hopfield(show_plot = True)

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -40,7 +40,9 @@ def example_mnist_rbm(paysage_path=None, num_epochs=10, show_plot=False):
                           scheduler=optimizers.PowerLawDecay(0.1))
 
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
-                                                method='stochastic')
+                                                method='stochastic',
+                                                beta_std = 1.0,
+                                                beta_momentum = 0.0)
 
     cd = fit.SGD(rbm, data, opt, num_epochs, method=fit.pcd, sampler=sampler,
                  mcsteps=mc_steps, monitor=perf)

--- a/examples/example_mnist_rbm.py
+++ b/examples/example_mnist_rbm.py
@@ -40,9 +40,7 @@ def example_mnist_rbm(paysage_path=None, num_epochs=10, show_plot=False):
                           scheduler=optimizers.PowerLawDecay(0.1))
 
     sampler = fit.DrivenSequentialMC.from_batch(rbm, data,
-                                                method='stochastic',
-                                                beta_std = 1.0,
-                                                beta_momentum = 0.0)
+                                                method='stochastic')
 
     cd = fit.SGD(rbm, data, opt, num_epochs, method=fit.pcd, sampler=sampler,
                  mcsteps=mc_steps, monitor=perf)

--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -30,7 +30,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     vis_layer = layers.BernoulliLayer(data.ncols)
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
-    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=1, num_random_samples=1,
+    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=0, num_random_samples=1,
                               tolerance_EMF=1e-4, max_iters_EMF=25, terms=num_terms)
     rbm.initialize(data, 'glorot_normal')
 

--- a/examples/example_mnist_tap_machine.py
+++ b/examples/example_mnist_tap_machine.py
@@ -14,6 +14,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     num_hidden_units = 256
     batch_size = 100
     learning_rate = 0.1
+    num_terms = 2
 
     (_, _, shuffled_filepath) = \
             util.default_paths(paysage_path)
@@ -29,8 +30,8 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     vis_layer = layers.BernoulliLayer(data.ncols)
     hid_layer = layers.BernoulliLayer(num_hidden_units)
 
-    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=0,
-                              tolerance_EMF=1e-4, max_iters_EMF=25, terms=2)
+    rbm = tap_machine.TAP_rbm([vis_layer, hid_layer], num_persistent_samples=1, num_random_samples=1,
+                              tolerance_EMF=1e-4, max_iters_EMF=25, terms=num_terms)
     rbm.initialize(data, 'glorot_normal')
 
     perf  = fit.ProgressMonitor(data,
@@ -45,7 +46,7 @@ def example_mnist_tap_machine(paysage_path=None, num_epochs = 10, show_plot=True
     sgd = fit.SGD(rbm, data, opt, num_epochs, method=fit.tap, monitor=perf)
 
     # fit the model
-    print('training with stochastic gradient ascent ')
+    print('Training with stochastic gradient ascent using TAP expansion to ' + str(num_terms) + ' terms.')
     sgd.train()
 
     util.show_metrics(rbm, perf)

--- a/examples/example_util.py
+++ b/examples/example_util.py
@@ -51,7 +51,7 @@ def show_metrics(rbm, performance):
     performance.check_progress(rbm, 0, show=True)
 
 def compute_reconstructions(rbm, v_data, fit):
-    sampler = fit.SequentialMC(rbm)
+    sampler = fit.DrivenSequentialMC(rbm)
     data_state = State.from_visible(v_data, rbm)
     sampler.set_positive_state(data_state)
     sampler.update_positive_state(1)
@@ -69,10 +69,10 @@ def show_reconstructions(rbm, v_data, fit, show_plot):
 def compute_fantasy_particles(rbm, v_data, fit):
     random_samples = rbm.random(v_data)
     model_state = State.from_visible(random_samples, rbm)
-    sampler = fit.SequentialMC(rbm)
+    sampler = fit.DrivenSequentialMC(rbm)
     sampler.set_negative_state(model_state)
     sampler.update_negative_state(1000)
-    v_model = rbm.deterministic_iteration(1, sampler.neg_state).units[0]
+    v_model = rbm.deterministic_iteration(10, sampler.neg_state).units[0]
 
     idx = numpy.random.choice(range(len(v_model)), 5, replace=False)
     return numpy.array([[be.to_numpy_array(v_model[i])] for i in idx])

--- a/examples/example_util.py
+++ b/examples/example_util.py
@@ -51,7 +51,7 @@ def show_metrics(rbm, performance):
     performance.check_progress(rbm, 0, show=True)
 
 def compute_reconstructions(rbm, v_data, fit):
-    sampler = fit.DrivenSequentialMC(rbm)
+    sampler = fit.SequentialMC(rbm)
     data_state = State.from_visible(v_data, rbm)
     sampler.set_positive_state(data_state)
     sampler.update_positive_state(1)
@@ -69,7 +69,7 @@ def show_reconstructions(rbm, v_data, fit, show_plot):
 def compute_fantasy_particles(rbm, v_data, fit):
     random_samples = rbm.random(v_data)
     model_state = State.from_visible(random_samples, rbm)
-    sampler = fit.DrivenSequentialMC(rbm)
+    sampler = fit.SequentialMC(rbm)
     sampler.set_negative_state(model_state)
     sampler.update_negative_state(1000)
     v_model = rbm.deterministic_iteration(1, sampler.neg_state).units[0]

--- a/paysage/backends/python_backend/matrix.py
+++ b/paysage/backends/python_backend/matrix.py
@@ -1162,7 +1162,7 @@ def fast_energy_distance(minibatch, samples, downsample=100):
     X = resample(minibatch, n, replace=True)
     Y = resample(samples, m, replace=True)
 
-    for i in range(n):
+    for i in range(n-1):
         for j in range(i+1, n):
             d1 += euclidean_distance(X[i], X[j])
     d1 = 2.0 * d1 / (n*n - n)

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -1279,7 +1279,7 @@ def fast_energy_distance(minibatch: T.FloatTensor,
     X = resample(minibatch, n, replace=True)
     Y = resample(samples, m, replace=True)
 
-    for i in range(n):
+    for i in range(n-1):
         for j in range(i+1, n):
             d1 += euclidean_distance(X[i], X[j])
     d1 = 2.0 * d1 / (n*n - n)

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -155,7 +155,7 @@ class SequentialMC(Sampler):
 
 class DrivenSequentialMC(Sampler):
     """An accelerated sequential Monte Carlo sampler"""
-    def __init__(self, model, beta_momentum=0.9, beta_std=0.2,
+    def __init__(self, model, beta_momentum=0.9, beta_std=0.6,
                  method='stochastic'):
         """
         Create a sequential Monte Carlo sampler.
@@ -199,7 +199,7 @@ class DrivenSequentialMC(Sampler):
 
         Notes:
             Modifies the folling attributes in place:
-                has_beta, beta_shape, beta_loc, beta_scale, beta
+                has_beta, beta_shape, beta
 
         Args:
             None

--- a/paysage/fit.py
+++ b/paysage/fit.py
@@ -153,9 +153,11 @@ class SequentialMC(Sampler):
                 +' method to set the initial state of the Markov Chain')
         self.neg_state = self.updater(steps, self.neg_state)
 
+# TODO: method to anneal the std -> 0 so that the sampled distribution
+# approaches the model distribution eventually
 class DrivenSequentialMC(Sampler):
     """An accelerated sequential Monte Carlo sampler"""
-    def __init__(self, model, beta_momentum=0.9, beta_std=0.6,
+    def __init__(self, model, beta_momentum=0.99, beta_std=0.6,
                  method='stochastic'):
         """
         Create a sequential Monte Carlo sampler.

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -1389,7 +1389,7 @@ class ExponentialLayer(Layer):
             rate -= be.dot(scaled_units[i], weights[i])
         rate += be.broadcast(self.params.loc, rate)
         if beta is not None:
-            rate = be.multiple(beta, rate)
+            rate = be.multiply(beta, rate)
         return rate
 
     def conditional_mode(self, scaled_units, weights, beta=None):

--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -574,10 +574,10 @@ class GaussianLayer(Layer):
         mean = be.dot(scaled_units[0], weights[0])
         for i in range(1, len(weights)):
             mean += be.dot(scaled_units[i], weights[i])
-        if beta is not None:
-            mean *= be.broadcast(beta, mean)
         mean += be.broadcast(self.params.loc, mean)
         var = be.broadcast(be.exp(self.params.log_var), mean)
+        if beta is not None:
+            var = be.divide(beta, var)
         return mean, var
 
     def conditional_mode(self, scaled_units, weights, beta=None):
@@ -847,9 +847,9 @@ class IsingLayer(Layer):
         field = be.dot(scaled_units[0], weights[0])
         for i in range(1, len(weights)):
             field += be.dot(scaled_units[i], weights[i])
-        if beta is not None:
-            field *= be.broadcast(beta,field)
         field += be.broadcast(self.params.loc, field)
+        if beta is not None:
+            field = be.multiply(beta, field)
         return field
 
     def conditional_mode(self, scaled_units, weights, beta=None):
@@ -1117,9 +1117,9 @@ class BernoulliLayer(Layer):
         field = be.dot(scaled_units[0], weights[0])
         for i in range(1, len(weights)):
             field += be.dot(scaled_units[i], weights[i])
-        if beta is not None:
-            field *= be.broadcast(beta, field)
         field += be.broadcast(self.params.loc, field)
+        if beta is not None:
+            field = be.multiply(beta, field)
         return field
 
     def conditional_mode(self, scaled_units, weights, beta=None):
@@ -1387,9 +1387,9 @@ class ExponentialLayer(Layer):
         rate = -be.dot(scaled_units[0], weights[0])
         for i in range(1, len(weights)):
             rate -= be.dot(scaled_units[i], weights[i])
-        if beta is not None:
-            rate *= be.broadcast(beta,rate)
         rate += be.broadcast(self.params.loc, rate)
+        if beta is not None:
+            rate = be.multiple(beta, rate)
         return rate
 
     def conditional_mode(self, scaled_units, weights, beta=None):

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -105,6 +105,7 @@ class TAP_rbm(model.Model):
             tol float: tolerance for quitting minimization.
             max_iters: maximum gradient decsent steps.
             terms: number of terms to use (1, 2, or 3 allowed)
+            method: one of 'gd' or 'constraint' picking which Gibbs FE minimization method to use.
 
         Returns:
             tuple (magnetization, TAP-approximated Helmholtz free energy)
@@ -113,6 +114,9 @@ class TAP_rbm(model.Model):
         """
         if terms not in [1, 2, 3]:
             raise ValueError("Must specify one, two, or three terms in TAP expansion training method")
+
+        if method not in ['gd', 'constraint']:
+            raise ValueError("Must specify a valid method for minimizing the Gibbs free energy")
 
         w = self.weights[0].params.matrix
         a = self.layers[0].params.loc

--- a/paysage/models/tap_machine.py
+++ b/paysage/models/tap_machine.py
@@ -25,7 +25,8 @@ class TAP_rbm(model.Model):
 
     """
 
-    def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-7, max_iters_EMF=100, num_persistent_samples=0):
+    def __init__(self, layer_list, terms=2, init_lr_EMF=0.1, tolerance_EMF=1e-7,
+                 max_iters_EMF=100, num_random_samples=1, num_persistent_samples=0):
         """
         Create a TAP RBM model.
 
@@ -34,14 +35,17 @@ class TAP_rbm(model.Model):
 
         Args:
             layer_list: A list of layers objects.
-            terms: number of terms to use in the TAP expansion (#TODO: deprecate this attribute when we turn tap training into a method and use tap1,tap2,tap3 as methods)
+            terms: number of terms to use in the TAP expansion
+            #TODO: deprecate this attribute when
+            we turn tap training into a method and use tap1,tap2,tap3 as methods
 
             EMF computation parameters:
                 init_lr float: initial learning rate which is halved whenever necessary to enforce descent.
                 tol float: tolerance for quitting minimization.
                 max_iters: maximum gradient decsent steps
-                number of persistent magnetization parameters to keep as seeds for gradient descent.
-                    0 implies we use a random seed each iteration
+                num_random_samples: number of Gibbs FE seeds to start from random
+                num_persistent_samples: number of persistent magnetization parameters to keep as seeds
+                    for Gibbs FE estimation.
 
         Returns:
             model: A TAP RBM model.
@@ -51,6 +55,7 @@ class TAP_rbm(model.Model):
         self.tolerance_EMF = tolerance_EMF
         self.max_iters_EMF = max_iters_EMF
         self.init_lr_EMF = init_lr_EMF
+        self.num_random_samples = num_random_samples
         self.persistent_samples = []
         for i in range (num_persistent_samples):
             self.persistent_samples.append(None)
@@ -61,26 +66,32 @@ class TAP_rbm(model.Model):
         self.terms = terms
 
 
-    def gibbs_free_energy(self, seed=None, init_lr=0.1, tol=1e-4, max_iters=50, terms=2):
+    def helmholtz_free_energy(self, seed=None, init_lr=0.1, tol=1e-4, max_iters=50, terms=2, method='gd'):
         """
-        Compute the Gibbs free engergy of the model according to the TAP
+        Compute the Helmholtz free engergy of the model according to the TAP
         expansion around infinite temperature to second order.
 
-        If the energy is:
+        If the energy is,
         '''
-            E(v, h) := -\langle a,v \rangle - \langle b,h \rangle - \langle v,W \cdot h \rangle, with state probability distribution:
-            P(v,h)  := 1/\sum_{v,h} \exp{-E(v,h)} * \exp{-E(v,h)}, and the marginal
-            P(v)    := \sum_{h} P(v,h)
+            E(v, h) := -\langle a,v \rangle - \langle b,h \rangle - \langle v,W \cdot h \rangle,
         '''
-        Then the Gibbs free energy is:
+        with Boltzmann probability distribution,
         '''
-            F(v) := -log\sum_{v,h} \exp{-E(v,h)}
+            P(v,h)  := 1/\sum_{v,h} \exp{-E(v,h)} * \exp{-E(v,h)},
+        '''
+        and the marginal,
+        '''
+            P(v)    := \sum_{h} P(v,h),
+        '''
+        then the Helmholtz free energy is,
+        '''
+            F(v) := -log\sum_{v,h} \exp{-E(v,h)}.
         '''
         We add an auxiliary local field q, and introduce the inverse temperature variable \beta to define
         '''
             \beta F(v;q) := -log\sum_{v,h} \exp{-\beta E(v,h) + \beta \langle q, v \rangle}
         '''
-        Let \Gamma(m) be the Legendre transform of F(v;q) as a function of q
+        Let \Gamma(m) be the Legendre transform of F(v;q) as a function of q, the Gibbs free energy.
         The TAP formula is Taylor series of \Gamma in \beta, around \beta=0.
         Setting \beta=1 and regarding the first two terms of the series as an approximation of \Gamma[m],
         we can minimize \Gamma in m to obtain an approximation of F(v;q=0) = F(v)
@@ -96,7 +107,7 @@ class TAP_rbm(model.Model):
             terms: number of terms to use (1, 2, or 3 allowed)
 
         Returns:
-            tuple (magnetization, TAP-approximated Gibbs free energy)
+            tuple (magnetization, TAP-approximated Helmholtz free energy)
                   (Magnetization, float)
 
         """
@@ -179,17 +190,20 @@ class TAP_rbm(model.Model):
                 gam_provisional = gamma(m_provisional)
                 if (gam - gam_provisional < 0):
                     lr *= 0.5
+                    #print("decreased lr" + str(its))
                     if (lr < 1e-10):
+                        #print("tol reached on iter" + str(its))
                         break
                 elif (gam - gam_provisional < tol):
                     break
                 else:
+                    #print(gam - gam_provisional)
                     m = m_provisional
                     gam = gam_provisional
 
             return (m, gam)
 
-        def minimize_gamma_constraint_sat(w, a, b, m, tol, max_iters, interpolation_factor=0.9):
+        def minimize_gamma_constraint_sat(w, a, b, m, tol, max_iters, interpolation_factor=1.0, terms=2):
             """
             Minimize Gamma via repeated application of the self-consistent constraint
 
@@ -197,27 +211,40 @@ class TAP_rbm(model.Model):
 
             """
             its = 0
-            gam = self.gamma_TAP2(m, w, a, b)
+            if terms == 1:
+                gamma = self.gamma_MF
+                cut2 = 0.0
+                cut3 = 0.0
+            elif terms == 2:
+                gamma = self.gamma_TAP2
+                cut2 = 1.0
+                cut3 = 0.0
+            elif terms == 3:
+                gamma = self.gamma_TAP3
+                cut2 = 1.0
+                cut3 = 1.0
+
+            gam = gamma(m)
             ww = be.multiply(w,w)
             while (its < max_iters):
                 its += 1
                 m_v_quad = m.v - be.multiply(m.v,m.v)
-                m_h_provisional = be.expit(b + be.dot(m.v,w) - be.dot(m_v_quad, be.dot(ww, m.h - 0.5)))
+                m_h_provisional = be.expit(b + be.dot(m.v,w) - cut2 * be.dot(m_v_quad, be.dot(ww, m.h - 0.5)))
                 m.h *= (1.0 - interpolation_factor)
                 m.h += interpolation_factor * m_h_provisional
 
                 m_h_quad = m.h - be.multiply(m.h,m.h)
-                m_v_provisional = be.expit(a + be.dot(w,m.h)-be.dot(m.v - 0.5, be.dot(ww, m_h_quad)))
+                m_v_provisional = be.expit(a + be.dot(w,m.h) - cut2 * be.dot(m.v - 0.5, be.dot(ww, m_h_quad)))
                 m.v *= (1.0 - interpolation_factor)
                 m.v += interpolation_factor * m_v_provisional
 
-                gam_update = self.gamma_TAP2(m, w, a, b)
+                gam_update = gamma(m)
                 if (abs(gam_update - gam) < tol):
+                    #print("stopped after " + str(its))
                     break
                 gam = gam_update
 
             return (m, gam)
-
 
         # generate random sample in domain to use as a starting location for gradient descent
         if seed==None :
@@ -228,8 +255,10 @@ class TAP_rbm(model.Model):
                 0.99 * be.float_tensor(be.rand((num_hidden_units,))) + 0.005
             )
 
-        return minimize_gamma_GD(w, a, b, seed, init_lr, tol, max_iters, terms)
-        #return minimize_gamma_constraint_sat(w, a, b, seed, tol, max_iters)
+        if method == 'gd':
+            return minimize_gamma_GD(w, a, b, seed, init_lr, tol, max_iters, terms=terms)
+        elif method == 'constraint':
+            return minimize_gamma_constraint_sat(w, a, b, seed, tol, max_iters,  terms=terms)
 
     # The Legendre transform of F(v;q) as a function of q according to Mean Field approximation
     # specialized to the RBM case
@@ -318,31 +347,40 @@ class TAP_rbm(model.Model):
         elif self.terms == 3:
              grad_w_gamma = self.grad_w_gamma_TAP3
 
-        # compute the TAP approximation to the Gibbs free energy:
+        # compute the TAP approximation to the Helmholtz free energy:
         EMF = 1e6
         m = None
-        if len(self.persistent_samples) == 0: # random seed
-                (m,EMF) = self.gibbs_free_energy(m,
+        num_p = len(self.persistent_samples)
+        num_r = self.num_random_samples
+        dw_EMF = be.zeros_like(w)
+        da_EMF = be.zeros_like(a)
+        db_EMF = be.zeros_like(b)
+        # compute minimizing magnetizations from random initializations
+        for s in range(num_r):
+            (m,EMF) = self.helmholtz_free_energy(None,
                                                  self.init_lr_EMF,
                                                  self.tolerance_EMF,
                                                  self.max_iters_EMF,
                                                  self.terms)
-        else:
-            best_EMF = 1e7
-            for s in range(len(self.persistent_samples)): # persistent seeds
-                (self.persistent_samples[s],EMF) = self.gibbs_free_energy(self.persistent_samples[s],
-                                                                          self.init_lr_EMF,
-                                                                          self.tolerance_EMF,
-                                                                          self.max_iters_EMF,
-                                                                          self.terms)
-                if EMF < best_EMF:
-                    best_EMF = EMF
-                    m = self.persistent_samples[s]
-
-        # Compute the gradients at this minimizing magnetization
-        dw_EMF = grad_w_gamma(m,w,a,b)
-        da_EMF = self.grad_a_gamma(m,w,a,b)
-        db_EMF = self.grad_b_gamma(m,w,a,b)
+            # Compute the gradients at this minimizing magnetization
+            dw_EMF += grad_w_gamma(m,w,a,b)
+            da_EMF += self.grad_a_gamma(m,w,a,b)
+            db_EMF += self.grad_b_gamma(m,w,a,b)
+        # compute minimizing magnetizations from seeded initializations
+        for s in range(num_p): # persistent seeds
+            (self.persistent_samples[s],EMF) = \
+             self.helmholtz_free_energy(self.persistent_samples[s],
+                                        self.init_lr_EMF,
+                                        self.tolerance_EMF,
+                                        self.max_iters_EMF,
+                                        self.terms)
+            # Compute the gradients at this minimizing magnetization
+            dw_EMF += grad_w_gamma(self.persistent_samples[s],w,a,b)
+            da_EMF += self.grad_a_gamma(self.persistent_samples[s],w,a,b)
+            db_EMF += self.grad_b_gamma(self.persistent_samples[s],w,a,b)
+        dw_EMF /= (num_p + num_r)
+        da_EMF /= (num_p + num_r)
+        db_EMF /= (num_p + num_r)
 
         # compute average grad_F_marginal over the minibatch
         intermediate = be.expit(be.add(be.unsqueeze(b,0), be.dot(data_state.units[0], w)))
@@ -364,3 +402,4 @@ class TAP_rbm(model.Model):
         #score = be.accumulate(self.marginal_free_energy, vdata)
         #print(-score / batch_size + EMF)
         return grad
+


### PR DESCRIPTION
The `DrivenSequentialMC` sampler augments the distribution `p(v, h)` with an additional variable `beta` and samples from a new distribution `p(v, h, beta) = p(v, h | beta) p(beta)`. The idea is that `beta` acts like an inverse temperature allowing the system to overcome energy barriers more easily when `beta < 1`. 

The current implementation samples `beta` from `p(beta)` that is an autocorrelated Gaussian distribution with mean 1. This is not the most clear choice of distribution -- for example, what does it mean for us when `beta < 0`? This branch switches to sampling `beta` from an autocorrelated Gamma distribution, which is the conjugate prior of inverse temperature (i.e., inverse variance) in Bayesian inference. 

The new implementation with the Gamma distribution is at least not worse than the old one with the Gaussian distribution, and I think it is generally a little better. But, it will also be much easier to reason about. For example, if we are using the new version to sample from a Gaussian-Gaussian RBM we know that the distribution we are actually sampling from is a Student-T distribution with the same mean. The exact distribution can be computed analytically in this case. It is not clear what distribution the old method was sampling from, which made it hard to reason about. 