### PR TITLE
Make heat capacity stable

### DIFF
--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -346,7 +346,7 @@ class Weights(Layer):
             self.get_penalty_grad(-be.batch_outer(vis, hid) / len(vis),
                                   "matrix"))
         return derivs
-    
+
 
     def GFE_derivatives(self, vis, hid):
         """
@@ -358,7 +358,7 @@ class Weights(Layer):
 
         Returns:
             derivs (namedtuple): 'matrix': tensor (contains gradient)
-            
+
         """
         return ParamsWeights(-be.outer(vis.expectation(), hid.expectation()) - \
           be.multiply(self.params.matrix, be.outer(vis.variance(), hid.variance())))
@@ -1015,7 +1015,7 @@ class MagnetizationBernoulli(object):
     MagnetizationBernoulli.expect, which are a float-valued in [0,1].
     The class presents a getter for the expectation as well as a
     function to compute the variance.
-    
+
     """
     def __init__(self, exp):
         self.expect = exp
@@ -1047,7 +1047,7 @@ class MagnetizationBernoulli(object):
 class GradientMagnetizationBernoulli(MagnetizationBernoulli):
     """
     This class represents a Bernoulli layer's contribution to the gradient vector
-    of the Gibbs free energy. 
+    of the Gibbs free energy.
     The underlying data is isomorphic to the MagnetizationBernoulli object.
     It provides two layer-wise functions used in the TAP method for training RBMs
 

--- a/paysage/math_utils.py
+++ b/paysage/math_utils.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+This module defines math utilities.
+
+"""
+
+class MeanVarianceCalculator(object):
+    """
+    An online numerically stable mean and variance calculator.
+    Uses Welford's algorithm for the variance.
+    B.P. Welford, Technometrics 4(3):419–420.
+
+    """
+    def __init__(self):
+        """
+        Create MeanVarianceCalculator object.
+
+        Args:
+            None
+
+        Returns:
+            The MeanVarianceCalculator object.
+
+        """
+        self.num = 0
+        self.mean = 0
+        self.var = 0
+
+    def reset(self) -> None:
+        """
+        Resets the calculation to the initial state.
+
+        Note:
+            Modifies the metric in place.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
+        self.num = 0
+        self.mean = 0
+        self.var = 0
+
+    def calculate(self, samples):
+        """
+        Run an online calculation of the mean and variance.
+
+        Notes:
+            The unnormalized variance is calculated
+                (not divided by the number of samples).
+
+        Args:
+            samples: data samples
+
+        Returns:
+            None
+
+        """
+        for s in samples:
+            self.num += 1
+            mean_update = self.mean + (s - self.mean) / self.num
+            self.var = (self.var*(self.num - 1) + (s - mean_update)*(s - self.mean)) / self.num
+            self.mean = mean_update

--- a/paysage/metrics.py
+++ b/paysage/metrics.py
@@ -445,11 +445,6 @@ class HeatCapacity(object):
         """
         energy = update_args.model.joint_energy(update_args.samples)
         self.calculate_variance(energy)
-        # self.norm += 1
-        # self.heat_capacity += be.mean(be.square(update_args.model
-        #                            .joint_energy(update_args.samples)))
-        # self.heat_capacity -= be.square(be.mean(update_args.model
-        #                            .joint_energy(update_args.samples)))
 
     def value(self) -> float:
         """


### PR DESCRIPTION
Heat capacity is a variance calculation, and the variance can have a catastrophic loss of precision when there is large cancellations between terms.

Switch to Welford's algorithm, which is more stable and still online.  Fixes #99.