### PR TITLE
Make the backends more consistent

### DIFF
--- a/paysage/backends/__init__.py
+++ b/paysage/backends/__init__.py
@@ -27,39 +27,6 @@ else:
 # ----- COMMON FUNCTIONALITY ----- #
 
 
-def fold(func, a):
-    """
-    Combines the result of a function over iterable a.
-
-    For example:
-
-    '''
-    from collections import namedtuple
-    from operator import add
-
-    coords = namedtuple("coordinates", ["x", "y"])
-
-    a = coords(1,2)
-    b = fold(add, a) # 3
-
-    a = list(a)
-    b = fold(add, a) # 3
-
-    '''
-
-    Args:
-        func (callable): a function with two arguments
-        a (iterable: e.g., list or named tuple)
-
-    Returns:
-        float
-
-    """
-    result = 0
-    for x in a:
-        result = func(result, x)
-    return result
-
 def accumulate(func, a):
     """
     Accumulates the result of a function over iterable a.

--- a/paysage/backends/python_backend/matrix.py
+++ b/paysage/backends/python_backend/matrix.py
@@ -442,7 +442,14 @@ def tmax(x: T.Tensor, axis: int=None, keepdims: bool=False)-> T.FloatingPoint:
             tensor: The maximum of the tensor along the specified axis.
 
     """
-    return numpy.max(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.max(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.max(x)
 
 def tmin(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
@@ -462,9 +469,16 @@ def tmin(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The minimum of the tensor along the specified axis.
 
     """
-    return numpy.min(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.min(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.min(x)
 
-def mean(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
+def mean(x: T.Tensor, axis: int = None, keepdims: bool = False) -> T.FloatingPoint:
     """
     Return the mean of the elements of a tensor along the specified axis.
 
@@ -482,7 +496,14 @@ def mean(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The mean of the tensor along the specified axis.
 
     """
-    return numpy.mean(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.mean(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.mean(x)
 
 def var(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
@@ -502,7 +523,14 @@ def var(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The variance of the tensor along the specified axis.
 
     """
-    return numpy.var(x, axis=axis, keepdims=keepdims, ddof=1)
+    if axis is not None:
+        tmp = numpy.var(x, axis=axis, keepdims=True, ddof=1)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.var(x, ddof=1)
 
 def std(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
@@ -522,7 +550,14 @@ def std(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The standard deviation of the tensor along the specified axis.
 
     """
-    return numpy.std(x, axis=axis, keepdims=keepdims, ddof=1)
+    if axis is not None:
+        tmp = numpy.std(x, axis=axis, keepdims=True, ddof=1)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.std(x, ddof=1)
 
 def tsum(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
@@ -542,7 +577,14 @@ def tsum(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The sum of the tensor along the specified axis.
 
     """
-    return numpy.sum(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.sum(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.sum(x)
 
 def tprod(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
     """
@@ -562,7 +604,14 @@ def tprod(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.FloatingPoint:
             tensor: The product of the tensor along the specified axis.
 
     """
-    return numpy.prod(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.prod(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.prod(x)
 
 def tany(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.Boolean:
     """
@@ -584,7 +633,14 @@ def tany(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.Boolean:
                                 along axis
 
     """
-    return numpy.any(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.any(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.any(x)
 
 def tall(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.Boolean:
     """
@@ -606,7 +662,14 @@ def tall(x: T.Tensor, axis: int=None, keepdims: bool=False) -> T.Boolean:
                                 along axis
 
     """
-    return numpy.all(x, axis=axis, keepdims=keepdims)
+    if axis is not None:
+        tmp = numpy.all(x, axis=axis, keepdims=True)
+        if keepdims:
+            return tmp
+        else:
+            return flatten(tmp)
+    else:
+        return numpy.all(x)
 
 def equal(x: T.Tensor, y: T.Tensor) -> T.Boolean:
     """
@@ -863,11 +926,11 @@ def add(a: T.Tensor, b: T.Tensor) -> T.Tensor:
         return a + b
     else:
         return broadcast(a, b) + b
-    
+
 def add_(a: T.Tensor, b: T.Tensor) -> None:
     """
     Add tensor a to tensor b using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -898,11 +961,11 @@ def subtract(a: T.Tensor, b: T.Tensor) -> T.Tensor:
         return b - a
     else:
         return b - broadcast(a, b)
-    
+
 def subtract_(a: T.Tensor, b: T.Tensor) -> None:
     """
     Subtract tensor a from tensor b using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -933,11 +996,11 @@ def multiply(a: T.Tensor, b: T.Tensor) -> T.Tensor:
         return a * b
     else:
         return broadcast(a, b) * b
-    
+
 def multiply_(a: T.Tensor, b: T.Tensor) -> None:
     """
     Multiply tensor b with tensor a using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -968,11 +1031,11 @@ def divide(a: T.Tensor, b: T.Tensor) -> T.Tensor:
         return b / a
     else:
         return b / broadcast(a, b)
-    
+
 def divide_(a: T.Tensor, b: T.Tensor) -> None:
     """
     Divide tensor b by tensor a using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -1379,23 +1379,3 @@ def fast_energy_distance(minibatch: T.FloatTensor,
     d3 = d3 / (n*m)
 
     return 2.0 * d3 - d2 - d1
-
-def replace_nan(x: T.FloatTensor, value: float = 0) -> T.FloatTensor:
-    """
-    Obtain a copy of the tensor with NaN replaced with a value,
-    as well as the mask of elements for persisted values or NaN.
-
-    Args:
-        x: A tensor.
-        value: The value to replace NaN with in tensor.
-
-    Returns:
-        t: a copy of the input tensor where NaN is replaced with a value.
-        mask: a tensor denoting whether each element
-              is a number (1/T) or NaN (0/F).
-
-    """
-    mask = (x==x)
-    t = value * torch.ones(x.size())
-    t.masked_copy_(mask, torch.masked_select(x, mask))
-    return t, mask.float()

--- a/paysage/backends/pytorch_backend/matrix.py
+++ b/paysage/backends/pytorch_backend/matrix.py
@@ -961,11 +961,11 @@ def add(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
         return a + b
     else:
         return broadcast(a, b) + b
-    
+
 def add_(a: T.FloatTensor, b: T.FloatTensor) -> None:
     """
     Add tensor a to tensor b using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -981,7 +981,7 @@ def add_(a: T.FloatTensor, b: T.FloatTensor) -> None:
         # no broadcasting necessary
         b.add_(a)
     else:
-        b.add_(broadcast(a, b))    
+        b.add_(broadcast(a, b))
 
 def subtract(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
     """
@@ -1000,11 +1000,11 @@ def subtract(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
         return b - a
     else:
         return b - broadcast(a, b)
-    
+
 def subtract_(a: T.FloatTensor, b: T.FloatTensor) -> None:
     """
     Subtract tensor a from tensor b using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -1039,11 +1039,11 @@ def multiply(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
         return a * b
     else:
         return broadcast(a, b) * b
-    
+
 def multiply_(a: T.FloatTensor, b: T.FloatTensor) -> None:
     """
     Multiply tensor b with tensor a using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -1078,11 +1078,11 @@ def divide(a: T.FloatTensor, b: T.FloatTensor) -> T.FloatTensor:
         return b / a
     else:
         return b / broadcast(a, b)
-    
+
 def divide_(a: T.FloatTensor, b: T.FloatTensor) -> None:
     """
     Divide tensor b by tensor a using broadcasting.
-    
+
     Notes:
         Modifies b in place.
 
@@ -1379,3 +1379,23 @@ def fast_energy_distance(minibatch: T.FloatTensor,
     d3 = d3 / (n*m)
 
     return 2.0 * d3 - d2 - d1
+
+def replace_nan(x: T.FloatTensor, value: float = 0) -> T.FloatTensor:
+    """
+    Obtain a copy of the tensor with NaN replaced with a value,
+    as well as the mask of elements for persisted values or NaN.
+
+    Args:
+        x: A tensor.
+        value: The value to replace NaN with in tensor.
+
+    Returns:
+        t: a copy of the input tensor where NaN is replaced with a value.
+        mask: a tensor denoting whether each element
+              is a number (1/T) or NaN (0/F).
+
+    """
+    mask = (x==x)
+    t = value * torch.ones(x.size())
+    t.masked_copy_(mask, torch.masked_select(x, mask))
+    return t, mask.float()

--- a/paysage/models/gradient_util.py
+++ b/paysage/models/gradient_util.py
@@ -17,13 +17,13 @@ Utility functions for manipulating Gradient objects
 def null_grad(model):
     """
     Return a gradient object filled with None.
-    
+
     Args:
         model: a Model object
-        
+
     Returns:
         Gradient
-    
+
     """
     return Gradient(
         [None for layer in model.layers],
@@ -33,29 +33,29 @@ def null_grad(model):
 def zero_grad(model):
     """
     Return a gradient object filled with zero tensors.
-    
+
     Args:
         model: a Model object
-        
+
     Returns:
         Gradient
-    
+
     """
     return Gradient(
         [be.apply(be.zeros_like, layer.params) for layer in model.layers],
         [be.apply(be.zeros_like, weight.params) for weight in model.weights]
         )
-    
+
 def random_grad(model):
     """
     Return a gradient object filled with random numbers.
-    
+
     Args:
         model: a Model object
-        
+
     Returns:
         Gradient
-    
+
     """
     return Gradient(
         [be.apply(be.rand_like, layer.params) for layer in model.layers],
@@ -77,14 +77,14 @@ def grad_fold(func, grad):
     """
     result = 0
     for layer in grad.layers:
-        result = be.fold(func, layer)
+        result += be.fold(func, layer)
     for weight in grad.weights:
-        result = be.fold(func, weight)
+        result += be.fold(func, weight)
     return result
 
 def grad_accumulate(func, grad):
     """
-    Apply a funciton entrywise over a Gradient object,
+    Apply a function entrywise over a Gradient object,
     accumulating the result.
 
     Args:
@@ -97,9 +97,9 @@ def grad_accumulate(func, grad):
     """
     result = 0
     for layer in grad.layers:
-        result = be.accumulate(func, layer)
+        result += be.accumulate(func, layer)
     for weight in grad.weights:
-        result = be.accumulate(func, weight)
+        result += be.accumulate(func, weight)
     return result
 
 def grad_apply(func, grad):

--- a/paysage/models/gradient_util.py
+++ b/paysage/models/gradient_util.py
@@ -62,26 +62,6 @@ def random_grad(model):
         [be.apply(be.rand_like, weight.params) for weight in model.weights]
         )
 
-def grad_fold(func, grad):
-    """
-    Apply a function entrywise over a Gradient objet,
-    combining the result.
-
-    Args:
-        func (callable): function with two arguments
-        grad (Gradient)
-
-    returns:
-        float
-
-    """
-    result = 0
-    for layer in grad.layers:
-        result += be.fold(func, layer)
-    for weight in grad.weights:
-        result += be.fold(func, weight)
-    return result
-
 def grad_accumulate(func, grad):
     """
     Apply a function entrywise over a Gradient object,

--- a/test/paysage/test_math_utils.py
+++ b/test/paysage/test_math_utils.py
@@ -19,7 +19,8 @@ def test_mean():
     for i in range(10):
         mv.update(s[i*10000:(i+1)*10000])
 
-    assert be.allclose(ref_mean, mv.mean)
+    assert be.allclose(be.float_tensor(np.array([ref_mean])),
+                       be.float_tensor(np.array([mv.mean])))
 
 
 # ----- MeanVarianceCalculator ----- #
@@ -37,8 +38,10 @@ def test_mean_variance():
     for i in range(10):
         mv.update(s[i*10000:(i+1)*10000])
 
-    assert be.allclose(ref_mean, mv.mean)
-    assert be.allclose(ref_var, mv.var)
+    assert be.allclose(be.float_tensor(np.array([ref_mean])),
+                       be.float_tensor(np.array([mv.mean])))
+    assert be.allclose(be.float_tensor(np.array([ref_var])),
+                       be.float_tensor(np.array([mv.var])))
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/paysage/test_math_utils.py
+++ b/test/paysage/test_math_utils.py
@@ -41,7 +41,8 @@ def test_mean_variance():
     assert be.allclose(be.float_tensor(np.array([ref_mean])),
                        be.float_tensor(np.array([mv.mean])))
     assert be.allclose(be.float_tensor(np.array([ref_var])),
-                       be.float_tensor(np.array([mv.var])))
+                       be.float_tensor(np.array([mv.var])),
+                       rtol=1e-4, atol=1e-7)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/test_derivatives.py
+++ b/test/test_derivatives.py
@@ -2,6 +2,7 @@ from paysage import backends as be
 from paysage import layers
 from paysage.models import model
 from paysage.models import gradient_util as gu
+import numpy
 import pytest
 from copy import deepcopy
 from cytoolz import partial
@@ -54,7 +55,7 @@ def test_grad_fold():
     grad = gu.random_grad(rbm)
 
     def test_func(x, y):
-        return be.norm(x) + be.norm(y)
+        return be.norm(be.float_tensor(numpy.array([x]))) + be.norm(y)
 
     gu.grad_fold(test_func, grad)
 
@@ -336,7 +337,7 @@ def test_bernoulli_GFE_derivatives():
 
     for lay in rbm.layers:
         lay.params.loc[:] = be.rand_like(lay.params.loc)
-        
+
     state = rbm.compute_StateTAP(init_lr=0.1, tol=1e-7, max_iters=50)
     GFE = rbm.gibbs_free_energy(state)
 
@@ -364,7 +365,7 @@ def test_bernoulli_GFE_derivatives():
                 lr *= 0.5
         else:
             break
-        
+
 def test_ising_conditional_params():
     num_visible_units = 100
     num_hidden_units = 50
@@ -627,10 +628,10 @@ def test_gaussian_conditional_params():
     hid_mean_func, hid_var_func = rbm.layers[1]._conditional_params(
         [vdata_scaled], [rbm.weights[0].W()])
 
-    assert be.allclose(visible_var, vis_var_func),\
+    assert be.allclose(visible_var, vis_var_func[0]),\
     "visible variance wrong in gaussian-gaussian rbm"
 
-    assert be.allclose(hidden_var, hid_var_func),\
+    assert be.allclose(hidden_var, hid_var_func[0]),\
     "hidden variance wrong in gaussian-gaussian rbm"
 
     assert be.allclose(visible_mean, vis_mean_func),\
@@ -716,7 +717,7 @@ def test_gaussian_derivatives():
 
     assert be.allclose(d_W, weight_derivs.matrix), \
     "derivative of weights wrong in gaussian-gaussian rbm"
-    
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/test_derivatives.py
+++ b/test/test_derivatives.py
@@ -39,26 +39,6 @@ def test_random_grad():
     # create a gradient object filled with random numbers
     gu.random_grad(rbm)
 
-def test_grad_fold():
-    num_visible_units = 100
-    num_hidden_units = 50
-
-    # set a seed for the random number generator
-    be.set_seed()
-
-    # set up some layer and model objects
-    vis_layer = layers.BernoulliLayer(num_visible_units)
-    hid_layer = layers.BernoulliLayer(num_hidden_units)
-    rbm = model.Model([vis_layer, hid_layer])
-
-    # create a gradient object filled with random numbers
-    grad = gu.random_grad(rbm)
-
-    def test_func(x, y):
-        return be.norm(be.float_tensor(numpy.array([x]))) + be.norm(y)
-
-    gu.grad_fold(test_func, grad)
-
 def test_grad_accumulate():
     num_visible_units = 100
     num_hidden_units = 50


### PR DESCRIPTION
`pytorch` is generally much stricter than `numpy` in terms of typing and shape requirements, which caused a few problems with getting consistent objects out of the two backends.  One example is that `numpy` can have a tensor of a single float, which has no shape information; this isn't allowed in `pytorch` (the tensor would have shape `(1,)`).

This PR makes the format of `numpy` arrays under certain backend operations consistent with the format of `pytorch` following suggestions from @drckf. There were also a few broken tests under the `pytorch` backend which are now fixed.