### PR TITLE
fix bug in GaussianLayer

### DIFF
--- a/paysage/layers.py
+++ b/paysage/layers.py
@@ -861,7 +861,7 @@ class GaussianLayer(Layer):
         super().__init__()
 
         self.len = num_units
-        self.rand = be.rand
+        self.rand = be.randn
         self.params = ParamsGaussian(be.zeros(self.len), be.zeros(self.len))
         self.mean_var_calc = math_utils.MeanVarianceCalculator()
 


### PR DESCRIPTION
On the last `layers` refactor, the random number generator for the Gaussian layer was incorrectly changed.  This fixes it.